### PR TITLE
    allow upscaling

### DIFF
--- a/cachelib/cachebench/workload/distributions/FastDiscrete.h
+++ b/cachelib/cachebench/workload/distributions/FastDiscrete.h
@@ -57,7 +57,7 @@ class FastDiscreteDistribution {
         sizes[i] -=
             facebook::cachelib::util::narrow_cast<size_t>(bucketPct * sizes[i]);
         probs[i] -= bucketPct * probs[i];
-        buckets.push_back(objectsSeen*scalingFactor_);
+        buckets.push_back(static_cast<uint64_t>(objectsSeen * scalingFactor_));
         if (bucketOffsets_.size() > 0) {
           bucketOffsets_.push_back(bucketOffsets_.back() + objectsSeen);
         }


### PR DESCRIPTION
The scaling mechanism was originally designed for *downscaling* the number of keys.  To allow upscaling, we need the following change.  Previously, upscaling had been done by directly editing the distribution files, but this change automates that process.