### PR TITLE
Fix build regression: Add nvmcache/NavyConfig.cpp to cachelib_allocator CMakeLists.txt

### DIFF
--- a/cachelib/allocator/CMakeLists.txt
+++ b/cachelib/allocator/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library (cachelib_allocator
     memory/SlabAllocator.cpp
     memory/Slab.cpp
     nvmcache/DipperItem.cpp
+    nvmcache/NavyConfig.cpp
     nvmcache/NavySetup.cpp
     NvmCacheState.cpp
     PoolOptimizer.cpp


### PR DESCRIPTION
Commit 8cedcf46b22c51ca6e1e15a150443a55aa175aa3 introduces a build regression related to an undefined reference in `NavyConfig`:

<details>
<summary>cmake build error</summary>

```
[  0%] Built target DATATYPEBENCH_thrift_target
[  0%] Built target BLOOM_thrift_target
[  1%] Built target SHM_thrift_target
[  2%] Built target SERIALIZATION_thrift_target
[  3%] Built target DATASTRUCT_SERIALIZE_thrift_target
[  3%] Built target SERIALIZE_thrift_target
[  4%] Built target DATASTRUCT_TESTS_thrift_target
[  5%] Built target MEMORY_SERIALIZE_thrift_target
[  5%] Built target thrift_generated_files
[ 20%] Built target cachelib_common
[ 28%] Built target cachelib_shm
[ 49%] Built target cachelib_navy
[ 83%] Built target cachelib_allocator
[ 85%] Built target cachelib_datatype
Scanning dependencies of target cachelib_cachebench
[ 97%] Built target cachelib_cachebench
Scanning dependencies of target cachebench
[ 98%] Linking CXX executable cachebench
../allocator/libcachelib_allocator.a(NavySetup.cpp.o): In function `facebook::cachelib::createDevice(facebook::cachelib::navy::NavyConfig const&, std::shared_ptr<facebook::cachelib::navy::DeviceEncryptor>)':
NavySetup.cpp:(.text+0x4665): undefined reference to `facebook::cachelib::navy::NavyConfig::getRaidPaths[abi:cxx11]() const'
NavySetup.cpp:(.text+0x4733): undefined reference to `facebook::cachelib::navy::NavyConfig::getRaidPaths[abi:cxx11]() const'
NavySetup.cpp:(.text+0x4a28): undefined reference to `facebook::cachelib::navy::NavyConfig::getFileName[abi:cxx11]() const'
collect2: error: ld returned 1 exit status
cachebench/CMakeFiles/cachebench.dir/build.make:142: recipe for target 'cachebench/cachebench' failed
make[2]: *** [cachebench/cachebench] Error 1
CMakeFiles/Makefile2:712: recipe for target 'cachebench/CMakeFiles/cachebench.dir/all' failed
make[1]: *** [cachebench/CMakeFiles/cachebench.dir/all] Error 2
Makefile:129: recipe for target 'all' failed
make: *** [all] Error 2
```
</details>

Adding the source file to the `cachelib_allocator` library fixes the compilation.