### PR TITLE
cmake build: Add install target for cachelib_datatype library

### DIFF
--- a/cachelib/datatype/CMakeLists.txt
+++ b/cachelib/datatype/CMakeLists.txt
@@ -6,6 +6,10 @@ add_library (cachelib_datatype
   )
 add_dependencies(cachelib_datatype thrift_generated_files)
 
+install(TARGETS cachelib_datatype
+        EXPORT cachelib-exports
+        DESTINATION ${LIB_INSTALL_DIR} )
+
 if (BUILD_TESTS)
   add_library (datatype_test_support
     tests/DataTypeTest.cpp)


### PR DESCRIPTION
Currently, `libcachelib_datatype.a` is not configured to be installed to `/usr/local/lib/` on `make install`, but is required as a link target for client applications.

This change adds an `install` target following the same structure for other library targets, like [`cachelib_allocator`](https://github.com/facebookincubator/CacheLib/blob/c90cac1a53fced776a590ccbee9f7dd6e57b6936/cachelib/allocator/CMakeLists.txt#L54) and others.