### PR TITLE
Fix cachebench for config with persistence enabled and NVM cache disabled

### DIFF
--- a/cachelib/allocator/CacheAllocator-inl.h
+++ b/cachelib/allocator/CacheAllocator-inl.h
@@ -3101,7 +3101,13 @@ std::optional<bool> CacheAllocator<CacheTrait>::saveNvmCache() {
     return false;
   }
 
-  nvmCacheState_.value().markSafeShutDown();
+  if (nvmCacheState_.has_value()) {
+    nvmCacheState_.value().markSafeShutDown();
+  }
+  else {
+    XLOG(ERR, "Could not mark NvmCacheState as safe shutdown.");
+    return false;
+  }
   return true;
 }
 

--- a/cachelib/allocator/CacheAllocator-inl.h
+++ b/cachelib/allocator/CacheAllocator-inl.h
@@ -204,8 +204,9 @@ void CacheAllocator<CacheTrait>::initNvmCache(bool dramCacheAttached) {
     return;
   }
 
-  nvmCacheState_.emplace(NvmCacheState(config_.cacheDir, config_.isNvmCacheEncryptionEnabled(),
-                                       config_.isNvmCacheTruncateAllocSizeEnabled()));
+  nvmCacheState_.emplace(
+      NvmCacheState(config_.cacheDir, config_.isNvmCacheEncryptionEnabled(),
+                    config_.isNvmCacheTruncateAllocSizeEnabled()));
 
   // for some usecases that create pools, restoring nvmcache when dram cache
   // is not persisted is not supported.
@@ -3103,8 +3104,7 @@ std::optional<bool> CacheAllocator<CacheTrait>::saveNvmCache() {
 
   if (nvmCacheState_.has_value()) {
     nvmCacheState_.value().markSafeShutDown();
-  }
-  else {
+  } else {
     XLOG(ERR, "Could not mark NvmCacheState as safe shutdown.");
     return false;
   }

--- a/cachelib/allocator/CacheAllocator.h
+++ b/cachelib/allocator/CacheAllocator.h
@@ -944,8 +944,17 @@ class CacheAllocator : public CacheBase {
   //
   // @return  time when the cache was created.
   time_t getCacheCreationTime() const noexcept { return cacheCreationTime_; }
+
+  // unix timestamp when the NVM cache was created. If NVM cahce isn't enaled,
+  // the cache creation time is returned instead.
+  //
+  // @return  time when the NVM cache was created.
   time_t getNVMCacheCreationTime() const {
-    return nvmCacheState_.getCreationTime();
+    auto result = getCacheCreationTime();
+    if (nvmCacheState_.has_value()) {
+      result = nvmCacheState_.value().getCreationTime();
+    }
+    return result;
   }
 
   // Inspects the cache without changing its state.
@@ -1782,7 +1791,7 @@ class CacheAllocator : public CacheBase {
   folly::ThreadLocal<TlsActiveItemRing, DummyTlsActiveItemRingTag> ring_;
 
   // state for the nvmcache
-  NvmCacheState nvmCacheState_;
+  std::optional<NvmCacheState> nvmCacheState_{};
 
   // admission policy for nvmcache
   std::shared_ptr<NvmAdmissionPolicy<CacheT>> nvmAdmissionPolicy_;

--- a/cachelib/allocator/CacheAllocator.h
+++ b/cachelib/allocator/CacheAllocator.h
@@ -945,12 +945,12 @@ class CacheAllocator : public CacheBase {
   // @return  time when the cache was created.
   time_t getCacheCreationTime() const noexcept { return cacheCreationTime_; }
 
-  // unix timestamp when the NVM cache was created. If NVM cahce isn't enaled,
-  // the cache creation time is returned instead.
+  // unix timestamp when the NVM cache was created.
+  // Return 0 if NVM cahce isn't enabled.
   //
   // @return  time when the NVM cache was created.
   time_t getNVMCacheCreationTime() const {
-    auto result = getCacheCreationTime();
+    time_t result = 0;
     if (nvmCacheState_.has_value()) {
       result = nvmCacheState_.value().getCreationTime();
     }

--- a/cachelib/allocator/CacheAllocatorConfig.h
+++ b/cachelib/allocator/CacheAllocatorConfig.h
@@ -83,6 +83,8 @@ class CacheAllocatorConfig {
   // Config for NvmCache. If enabled, cachelib will also make use of flash.
   CacheAllocatorConfig& enableNvmCache(NvmCacheConfig config);
 
+  bool isNvmCacheEnabled() const;
+
   // enable the reject first admission policy through its parameters
   // @param numEntries          the number of entries to track across all splits
   // @param numSplits           the number of splits. we drop a whole split by
@@ -660,6 +662,11 @@ CacheAllocatorConfig<T>& CacheAllocatorConfig<T>::enableNvmCache(
     NvmCacheConfig config) {
   nvmConfig.assign(config);
   return *this;
+}
+
+template <typename T>
+bool CacheAllocatorConfig<T>::isNvmCacheEnabled() const {
+  return nvmConfig.has_value();
 }
 
 template <typename T>


### PR DESCRIPTION
Converted "NvmCacheState CacheAllocator::nvmCacheState_" to "std::optional<NvmCacheState>CacheAllocator::nvmCacheState_" to simplify NVM cache state handling when NVM cache is not enabled. This fixes an error message generated during cachebench run with cache persistence enabled and NVM cache disabled: "[...NvmCacheState.cpp:135] unable to deserialize nvm metadata file: no content in file: <path>/NvmCacheState".
