### PR TITLE
Disable pool rebalancing when cache eviction is disabled.

### DIFF
--- a/cachelib/allocator/CacheAllocator-inl.h
+++ b/cachelib/allocator/CacheAllocator-inl.h
@@ -379,7 +379,7 @@ CacheAllocator<CacheTrait>::allocateChainedItemInternal(
   (*stats_.allocAttempts)[pid][cid].inc();
 
   void* memory = allocator_->allocate(pid, requiredSize);
-  if (memory == nullptr) {
+  if (memory == nullptr && !config_.disableEviction) {
     memory = findEviction(pid, cid);
   }
   if (memory == nullptr) {

--- a/cachelib/allocator/CacheAllocator-inl.h
+++ b/cachelib/allocator/CacheAllocator-inl.h
@@ -2351,7 +2351,7 @@ void CacheAllocator<CacheTrait>::releaseSlabImpl(
     const bool isMoved = moveForSlabRelease(releaseContext, item, throttler);
 
     // if moving fails, evict it
-    if (!isMoved) {
+    if (!isMoved && !config_.disableEviction) {
       evictForSlabRelease(releaseContext, item, throttler);
     }
     XDCHECK(allocator_->isAllocFreed(releaseContext, alloc));

--- a/cachelib/allocator/tests/BaseAllocatorTest.h
+++ b/cachelib/allocator/tests/BaseAllocatorTest.h
@@ -3655,6 +3655,9 @@ class BaseAllocatorTest : public AllocatorTest<AllocatorT> {
     typename AllocatorT::Config config;
     config.disableCacheEviction();
     config.setCacheSize((numSlabs + 1) * Slab::kSize);
+
+    // Disable slab rebalancing
+    config.enablePoolRebalancing(nullptr, std::chrono::milliseconds{0});
     AllocatorT allocator(config);
 
     const size_t numBytes = allocator.getCacheMemoryStats().cacheSize;


### PR DESCRIPTION
testAllocateWithoutEviction was failing randomly at `XDCHECK(!config_.disableEviction);` in evictForSlabRelease.

I used the same approach as in different tests but I was also wondering if there should be some extra check (perhaps in config::validate?) to make sure poolRebalancer is not running when eviction is disabled.

