### PR TITLE
Do not reimplement getMaxAddressableSize in config.

### DIFF
--- a/cachelib/allocator/CacheAllocatorConfig.h
+++ b/cachelib/allocator/CacheAllocatorConfig.h
@@ -974,11 +974,7 @@ const CacheAllocatorConfig<T>& CacheAllocatorConfig<T>::validate() const {
         "Tail hits tracking cannot be enabled on MMTypes except MM2Q.");
   }
 
-  // The first part determines max number of "slots" we can address using
-  // CompressedPtr;
-  // The second part specifies the minimal allocation size for each slot.
-  // Multiplied, they inform us the maximal addressable space for cache.
-  size_t maxCacheSize = (1ul << CompressedPtr::kNumBits) * Slab::kMinAllocSize;
+  size_t maxCacheSize = CompressedPtr::getMaxAddressableSize();
   // Configured cache size should not exceed the maximal addressable space for
   // cache.
   if (size > maxCacheSize) {


### PR DESCRIPTION
There is already a method within CompressedPtr that can
be used.