### PR TITLE
Fix tests and benchmarks compilation

### DIFF
--- a/cachelib/common/CMakeLists.txt
+++ b/cachelib/common/CMakeLists.txt
@@ -50,6 +50,9 @@ if (BUILD_TESTS)
   add_library (common_test_utils STATIC
     TestUtils.cpp
   )
+  target_link_libraries(common_test_utils PUBLIC
+    Folly::folly
+  )
   add_library (common_test_support OBJECT
     hothash/HotHashDetectorTest.cpp
     piecewise/GenericPiecesTest.cpp


### PR DESCRIPTION
Compilation of some of the tests was failing with:
"undefined reference to `facebook::cachelib::test_util::getRandomAsciiStr[abi:cxx11](unsigned int)'"

on CMake 3.20.2 and  GCC 8.5.0

Fix this by linking those tests with common/TestUtils.cpp

Also, for some reason, specifying sources as in
add_library(common_test_support INTERFACE [sources...]) did not work.
Using target_sources works fine.