### PR TITLE
add packit config for packaging CI

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,25 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration
+
+specfile_path: cachelib.spec
+
+upstream_package_name: CacheLib
+downstream_package_name: cachelib
+
+actions:
+  fix-spec-file: 
+  - bash -c "sed -i cachelib.spec -e \"s/%global commit.*/%global commit $(git rev-parse HEAD)/\""
+  - bash -c "sed -i cachelib.spec -e \"s/%global date.*/%global date $(git show -s --date=format:'%Y%m%d' --format=%cd)/\""
+  create-archive:
+  - bash -c "COMMIT=$(git rev-parse HEAD); curl -ORL https://github.com/facebook/CacheLib/archive/${COMMIT}/cachelib-${COMMIT}.tar.gz; echo cachelib-${COMMIT}.tar.gz"
+  post-upstream-clone: "bash -c \"rm -rf cachelib-dist-git; git clone -b packit https://pagure.io/meta/cachelib.git cachelib-dist-git && mv cachelib-dist-git/cachelib*.{spec,patch} .\""
+
+jobs:
+- job: copr_build
+  trigger: pull_request
+  metadata:
+    targets:
+    - fedora-rawhide-aarch64
+    - fedora-rawhide-x86_64
+    - fedora-35-aarch64
+    - fedora-35-x86_64


### PR DESCRIPTION
Summary:
Configure so every PR triggers a scratch build on Fedora.

TagIt just got enabled, so this will be revised next week to also build tagged
commits.

Differential Revision: D35119693

