### PR TITLE
fix clang-format-check GH Action

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run clang-format style check for C/C++ programs.
-      uses: jidicula/clang-format-action@v3.4.0
+      uses: jidicula/clang-format-action@v4.6.2
       with:
-        clang-format-version: '11'
+        clang-format-version: '13'
         check-path: ${{ matrix.path }}


### PR DESCRIPTION
Summary:
This was using an old version of `clang-format-action` that uses Ubuntu Groovy
(20.10) that is EOLed so installing `clang-format` failed as the repos are no
longer available.

Switch to the latest version and use Clang 13, not 11.

Differential Revision: D35120055

