### PR TITLE
fix common tests

### DIFF
--- a/cachelib/allocator/CMakeLists.txt
+++ b/cachelib/allocator/CMakeLists.txt
@@ -78,7 +78,6 @@ install(TARGETS cachelib_allocator
 
 if (BUILD_TESTS)
   add_library (allocator_test_support OBJECT
-    ../common/TestUtils.cpp
     ${DATASTRUCT_TESTS_THRIFT_FILES}
     ./nvmcache/tests/NvmTestBase.cpp
     ./memory/tests/TestBase.cpp
@@ -86,6 +85,7 @@ if (BUILD_TESTS)
   add_dependencies(allocator_test_support thrift_generated_files)
   target_link_libraries (allocator_test_support PUBLIC
     cachelib_allocator
+    common_test_utils
     glog::glog
     gflags
     GTest::gtest

--- a/cachelib/common/CMakeLists.txt
+++ b/cachelib/common/CMakeLists.txt
@@ -47,14 +47,17 @@ install(TARGETS cachelib_common
 
 
 if (BUILD_TESTS)
-  add_library (common_test_support PUBLIC
+  add_library (common_test_utils STATIC
     TestUtils.cpp
+  )
+  add_library (common_test_support OBJECT
     hothash/HotHashDetectorTest.cpp
     piecewise/GenericPiecesTest.cpp
     piecewise/RequestRangeTest.cpp
   )
   target_link_libraries (common_test_support PUBLIC
     cachelib_common
+    common_test_utils
     gflags
     GTest::gtest
     GTest::gtest_main

--- a/cachelib/compact_cache/CMakeLists.txt
+++ b/cachelib/compact_cache/CMakeLists.txt
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 if (BUILD_TESTS)
-  add_library (compact_cache_test_support OBJECT ../common/TestUtils.cpp)
+  add_library (compact_cache_test_support INTERFACE)
 
-  target_link_libraries (compact_cache_test_support PUBLIC
+  target_link_libraries (compact_cache_test_support INTERFACE
     cachelib_allocator
+    common_test_utils
     glog::glog
     gflags
     GTest::gtest


### PR DESCRIPTION
Summary:
`cachelib/common/CMakeLists.txt` was refactored in D35078825 (https://github.com/facebook/CacheLib/commit/4a8fcfa51618d1143b5fb243dd539ff8b2ecc66b) to lower the
minimum CMake version, but introduced an error in `add_library`.

Fix this so tests can be properly built again. Also D34908404 (https://github.com/facebook/CacheLib/commit/3ea95d54b05e3a0190e53e4edf4b0ae4697cc2fc) relied on
INTERFACE libraries being allowed to have source files to work around TestUtils
being needed by several projects; it is now factored out to its own
STATIC library.

Differential Revision: D35131251

