### PR TITLE
Set limit for bucketPower on config with #cacheEntries

### DIFF
--- a/cachelib/allocator/ChainedHashTable.h
+++ b/cachelib/allocator/ChainedHashTable.h
@@ -272,7 +272,7 @@ class ChainedHashTable {
     }
 
     // Estimate bucketsPower and LocksPower based on cache entries.
-    void sizeBucketsPowerAndLocksPower(size_t cacheEntries) noexcept {
+    void sizeBucketsPowerAndLocksPower(size_t cacheEntries) {
       // The percentage of used buckets vs unused buckets is measured by a load
       // factor. For optimal performance, the load factor should not be more
       // than 60%.

--- a/cachelib/allocator/ChainedHashTable.h
+++ b/cachelib/allocator/ChainedHashTable.h
@@ -276,10 +276,14 @@ class ChainedHashTable {
       // The percentage of used buckets vs unused buckets is measured by a load
       // factor. For optimal performance, the load factor should not be more
       // than 60%.
-      bucketsPower_ = std::max<unsigned int>(
-          kMaxBucketPower,
-          static_cast<size_t>(
-              ceil(log2(cacheEntries * 1.6 /* load factor */))));
+      bucketsPower_ =
+          static_cast<size_t>(ceil(log2(cacheEntries * 1.6 /* load factor */)));
+
+      if (bucketsPower_ > kMaxBucketPower) {
+        throw std::invalid_argument(folly::sformat(
+            "Invalid arguments to the config constructor cacheEntries =  {}",
+            cacheEntries));
+      }
 
       // 1 lock per 1000 buckets.
       locksPower_ = std::max<unsigned int>(1, bucketsPower_ - 10);

--- a/cachelib/allocator/ChainedHashTable.h
+++ b/cachelib/allocator/ChainedHashTable.h
@@ -276,8 +276,10 @@ class ChainedHashTable {
       // The percentage of used buckets vs unused buckets is measured by a load
       // factor. For optimal performance, the load factor should not be more
       // than 60%.
-      bucketsPower_ =
-          static_cast<size_t>(ceil(log2(cacheEntries * 1.6 /* load factor */)));
+      bucketsPower_ = std::max<unsigned int>(
+          kMaxBucketPower,
+          static_cast<size_t>(
+              ceil(log2(cacheEntries * 1.6 /* load factor */))));
 
       // 1 lock per 1000 buckets.
       locksPower_ = std::max<unsigned int>(1, bucketsPower_ - 10);

--- a/cachelib/allocator/tests/ChainedHashTest.cpp
+++ b/cachelib/allocator/tests/ChainedHashTest.cpp
@@ -30,6 +30,9 @@ TEST(ChainedHashTableConfigTest, Size) {
   config.sizeBucketsPowerAndLocksPower(1000000);
   EXPECT_EQ(config.getBucketsPower(), 21);
   EXPECT_EQ(config.getLocksPower(), 11);
+
+  ASSERT_THROW(config.sizeBucketsPowerAndLocksPower(2700000000),
+               std::invalid_argument);
 }
 
 TEST_F(ChainedHashTest, Insert) { testInsert(); }


### PR DESCRIPTION
This PR fixes the potential bug of exceeding the limit for bucketPower and lockPower, by capping the bucketPower with kMaxBucketPower. 

Fix: https://github.com/facebook/CacheLib/issues/125