### PR TITLE
Extend cachbench with value validation

### DIFF
--- a/cachelib/cachebench/cache/Cache.h
+++ b/cachelib/cachebench/cache/Cache.h
@@ -65,9 +65,11 @@ class Cache {
   //                      cache.
   // @param cacheDir      optional directory for the cache to enable
   //                      persistence across restarts.
+  // @param touchValue    read entire value on find
   explicit Cache(const CacheConfig& config,
                  ChainedItemMovingSync movingSync = {},
-                 std::string cacheDir = "");
+                 std::string cacheDir = "",
+                 bool touchValue = false);
 
   ~Cache();
 
@@ -179,6 +181,9 @@ class Cache {
     return getSize(item.get());
   }
 
+  // read entire value on find.
+  void touchValue(const ReadHandle& it) const;
+
   // returns the size of the item, taking into account ItemRecords could be
   // enabled.
   uint32_t getSize(const Item* item) const noexcept;
@@ -240,6 +245,9 @@ class Cache {
 
   // returns true if the consistency checking is enabled.
   bool consistencyCheckEnabled() const { return valueTracker_ != nullptr; }
+
+  // returns true if touching value is enabled.
+  bool touchValueEnabled() const { return touchValue_; }
 
   // return true if the key was previously detected to be inconsistent. This
   // is useful only when consistency checking is enabled by calling
@@ -362,6 +370,9 @@ class Cache {
 
   // tracker for consistency monitoring.
   std::unique_ptr<ValueTracker> valueTracker_;
+
+  // read entire value on find.
+  bool touchValue_{false};
 
   // reading of the nand bytes written for the benchmark if enabled.
   const uint64_t nandBytesBegin_{0};

--- a/cachelib/cachebench/runner/CacheStressor.h
+++ b/cachelib/cachebench/runner/CacheStressor.h
@@ -95,7 +95,8 @@ class CacheStressor : public Stressor {
       cacheConfig.ticker = ticker_;
     }
 
-    cache_ = std::make_unique<CacheT>(cacheConfig, movingSync);
+    cache_ = std::make_unique<CacheT>(cacheConfig, movingSync, "",
+                                      config_.touchValue);
     if (config_.opPoolDistribution.size() > cache_->numPools()) {
       throw std::invalid_argument(folly::sformat(
           "more pools specified in the test than in the cache. "

--- a/cachelib/cachebench/util/Config.cpp
+++ b/cachelib/cachebench/util/Config.cpp
@@ -34,6 +34,7 @@ StressorConfig::StressorConfig(const folly::dynamic& configJson) {
   JSONSetVal(configJson, samplingIntervalMs);
 
   JSONSetVal(configJson, checkConsistency);
+  JSONSetVal(configJson, touchValue);
 
   JSONSetVal(configJson, numOps);
   JSONSetVal(configJson, numThreads);

--- a/cachelib/cachebench/util/Config.h
+++ b/cachelib/cachebench/util/Config.h
@@ -194,6 +194,10 @@ struct StressorConfig : public JSONConfig {
   // output stats after warmup.
   bool checkNvmCacheWarmUp{false};
 
+  // If enabled, each value will be read on find. This is useful for measuring
+  // performance of value access.
+  bool touchValue{false};
+
   uint64_t numOps{0};     // operation per thread
   uint64_t numThreads{0}; // number of threads that will run
   uint64_t numKeys{0};    // number of keys that will be used


### PR DESCRIPTION
The main purpose of this patch is to better simulate workloads in
cachebench. Setting validateValue to true allows to see performance
impact of using different mediums for memory cache.