### PR TITLE
fix anon-struct usage that's a warning/error -Wnon-c-typedef-for-linkage

### DIFF
--- a/cachelib/compact_cache/CCacheDescriptor.h
+++ b/cachelib/compact_cache/CCacheDescriptor.h
@@ -159,7 +159,7 @@ template <unsigned MaxSize>
 struct VariableSizedValueDescriptor {
   constexpr static bool kFixedSize = false;
 
-  using Value = struct {
+  struct Value {
     char data[0];
     // Data is here.
   } __attribute__((__packed__));

--- a/cachelib/compact_cache/CCacheFixedLruBucket.h
+++ b/cachelib/compact_cache/CCacheFixedLruBucket.h
@@ -48,7 +48,7 @@ struct FixedLruBucket {
 
   /** Type of the data stored in a bucket entry.
    *  This contains the key and the value (if any). */
-  using Entry = struct {
+  struct Entry {
     Key key;
     /* Expands to NoValue (size 0) if this cache does not store values */
     Value val;
@@ -56,7 +56,7 @@ struct FixedLruBucket {
 
   /** Type of a bucket.
    * Empty entry slots must be zeroed out to avoid spurious matches! */
-  using Bucket = struct {
+  struct Bucket {
     Entry entries[kEntriesPerBucket];
   } __attribute__((__packed__));
 

--- a/cachelib/compact_cache/CCacheVariableLruBucket.h
+++ b/cachelib/compact_cache/CCacheVariableLruBucket.h
@@ -131,7 +131,7 @@ struct VariableLruBucket {
   constexpr static size_t kMaxEntries = std::numeric_limits<EntryNum>::max();
 
   /** An entry header. */
-  using EntryHdr = struct {
+  struct EntryHdr {
     Key key;
     /* Size in bytes of the corresponding EntryData's data field. */
     EntryDataSize dataSize;
@@ -140,7 +140,7 @@ struct VariableLruBucket {
     EntryDataOffset dataOffset;
   } __attribute__((__packed__));
 
-  using EntryData = struct {
+  struct EntryData {
     /* Index of the corresponding EntryHdr header in the 'Entry
      * Headers' section. This is a value between 0 and the number of entries
      * in the bucket. */
@@ -155,7 +155,7 @@ struct VariableLruBucket {
   constexpr static size_t kBucketDataSize =
       kMaxValueSize + sizeof(EntryHdr) + sizeof(EntryData);
 
-  using Bucket = struct {
+  struct Bucket {
     /* Number of entries in the bucket. */
     EntryNum numEntries;
     /* Size of the "Data" section.


### PR DESCRIPTION
Summary:
Fix
  error: anonymous non-C-compatible type given name for linkage purposes by alias declaration; add a tag name here [-Werror,-Wnon-c-typedef-for-linkage]

Reviewed By: philippv

Differential Revision: D36043476

