### PR TITLE
make announcementBarContent change style (mobile)

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -80,13 +80,13 @@ div[class^="announcementBarContent"] a:hover {
 }
 
 @media only screen and (max-width: 768px) {
-  .announcement {
+  div[class^="announcementBarContent"] {
     font-size: 18px;
   }
 }
 
 @media only screen and (max-width: 500px) {
-  .announcement {
+  div[class^="announcementBarContent"] {
     font-size: 15px;
     line-height: 22px;
     padding: 6px 30px;


### PR DESCRIPTION
![cachelib org_](https://user-images.githubusercontent.com/78584173/166887240-e9a10557-bce9-4355-a09e-144505d76c42.png)

# Code
The actual class is `.announcementBarContent_6uhP` and `.announcement` does not select the banner.
It should be `div[class^="announcementBarContent"]`.