### PR TITLE
Tracking per-pool usage stats

### DIFF
--- a/cachelib/cachebench/cache/CacheStats.h
+++ b/cachelib/cachebench/cache/CacheStats.h
@@ -32,6 +32,8 @@ struct Stats {
   uint64_t allocAttempts{0};
   uint64_t allocFailures{0};
 
+  std::vector<double> poolUsageFraction;
+
   uint64_t numCacheGets{0};
   uint64_t numCacheGetMiss{0};
   uint64_t numRamDestructorCalls{0};
@@ -115,6 +117,12 @@ struct Stats {
                           invertPctFn(allocFailures, allocAttempts))
         << std::endl;
     out << folly::sformat("RAM Evictions : {:,}", numEvictions) << std::endl;
+
+    for (auto pid = 0U; pid < poolUsageFraction.size(); pid++) {
+      out << folly::sformat("Fraction of pool {:,} used : {:.2f}", pid,
+                            poolUsageFraction[pid])
+          << std::endl;
+    }
 
     if (numCacheGets > 0) {
       out << folly::sformat("Cache Gets    : {:,}", numCacheGets) << std::endl;


### PR DESCRIPTION
This per pool size statistics reports the current used space in each memory pool. Pool Usage = PoolStats->poolUsableSize - PoolStats->freeMemoryBytes(). This statistics will be reported in the final report generated by cachebench.