### PR TITLE
Fix navy compilation issue

### DIFF
--- a/cachelib/navy/CMakeLists.txt
+++ b/cachelib/navy/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library (cachelib_navy
   common/SizeDistribution.cpp
   common/Types.cpp
   driver/Driver.cpp
+  engine/EnginePair.cpp
   Factory.cpp
   scheduler/ThreadPoolJobScheduler.cpp
   scheduler/ThreadPoolJobQueue.cpp


### PR DESCRIPTION
EnginePair.cpp file was not added to CMakeLists.txt which led to linking failure.