### PR TITLE
contrib: support build prefix in build scripts

### DIFF
--- a/contrib/build-package.sh
+++ b/contrib/build-package.sh
@@ -78,7 +78,9 @@ build_tests=
 show_help=
 many_jobs=
 verbose=
-while getopts :BSdhijtv param
+PREFIX="$PWD/opt/cachelib/"
+
+while getopts :BSdhijtvp: param
 do
   case $param in
     i) install=yes ;;
@@ -89,6 +91,7 @@ do
     v) verbose=yes ;;
     j) many_jobs=yes ;;
     t) build_tests=yes ;;
+    p) PREFIX=$OPTARG ;;
     ?) die "unknown option. See -h for help."
   esac
 done
@@ -97,8 +100,6 @@ shift $((OPTIND-1))
 
 test "$#" -eq 0 \
     && die "missing dependancy name to build. See -h for help"
-
-
 
 ######################################
 ## Check which dependecy was requested
@@ -275,7 +276,6 @@ test -d cachelib || die "expected 'cachelib' directory not found in $PWD"
 
 
 # After ensuring we are in the correct directory, set the installation prefix"
-PREFIX="$PWD/opt/cachelib/"
 CMAKE_PARAMS="$CMAKE_PARAMS -DCMAKE_INSTALL_PREFIX=$PREFIX"
 CMAKE_PREFIX_PATH="$PREFIX/lib/cmake:$PREFIX/lib64/cmake:$PREFIX/lib:$PREFIX/lib64:$PREFIX:${CMAKE_PREFIX_PATH:-}"
 export CMAKE_PREFIX_PATH

--- a/contrib/build.sh
+++ b/contrib/build.sh
@@ -125,7 +125,7 @@ skip_os_pkgs=
 skip_build=
 show_help=
 build_cachelib_tests=
-while getopts BdhjOStvT param
+while getopts BdhjOStvTp: param
 do
   case $param in
   h)  show_help=yes ;;
@@ -133,6 +133,7 @@ do
   B)  skip_build=yes ;;
   d|j|S|t|v) pass_params="$pass_params -$param" ;;
   T)  build_cachelib_tests=yes ;;
+  p)  pass_params="$pass_params -$param $OPTARG" ;;
   ?)      die "unknown option. See -h for help."
   esac
 done


### PR DESCRIPTION
Currently, the build prefix defaults to the subdirectory under the source directory (i.e., $SRCDIR/opt/cachelib), meaning the build artifacts needs to be installed on the same path as the source path which limits the portability/usability. This change fixes by adding the support for passing the build prefix (-p) in build script explicitly. E.g., the build prefix can be specified as follows.

contrib/build.sh -jO -p /opt/cachelib