### PR TITLE
contrib: support installation on Arch Linux

### DIFF
--- a/contrib/build.sh
+++ b/contrib/build.sh
@@ -81,6 +81,12 @@ build_fedora_34()
     || die "failed to install packages for Fedora"
 }
 
+build_arch()
+{
+  ./contrib//prerequisites-arch.sh \
+    || die "failed to install packages for ArchLinux"
+}
+
 build_dependencies()
 {
   for pkg in zstd googleflags googlelog googletest sparsemap fmt folly fizz wangle fbthrift ;
@@ -155,6 +161,7 @@ if test -z "$skip_os_pkgs" ; then
     centos8|rocky8.?) build_centos_8 ;;
     rocky9.?) build_rocky_9 ;;
     fedora3[456]) build_fedora_34 ;;
+    arch*|manjaro*) build_arch ;;
     *) die "No build recipe for detected operating system '$DETECTED'" ;;
   esac
 fi

--- a/contrib/prerequisites-arch.sh
+++ b/contrib/prerequisites-arch.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sudo pacman -S --needed --noconfirm cmake \
+  make \
+  gcc \
+  boost \
+  double-conversion \
+  libdwarf \
+  libsodium


### PR DESCRIPTION
This PR enables CacheLib to be installed on Arch Linux.

I am an Arch Linux user, and I have tested it on my own machine.