### PR TITLE
Add combined locking support for MMContainer

### DIFF
--- a/cachelib/allocator/CacheAllocator.h
+++ b/cachelib/allocator/CacheAllocator.h
@@ -1660,7 +1660,7 @@ class CacheAllocator : public CacheBase {
   // @return An evicted item or nullptr  if there is no suitable candidate.
   Item* findEviction(PoolId pid, ClassId cid);
 
-  using EvictionIterator = typename MMContainer::Iterator;
+  using EvictionIterator = typename MMContainer::LockedIterator;
 
   // Advance the current iterator and try to evict a regular item
   //

--- a/cachelib/allocator/MM2Q-inl.h
+++ b/cachelib/allocator/MM2Q-inl.h
@@ -241,29 +241,21 @@ bool MM2Q::Container<T, HookPtr>::add(T& node) noexcept {
 }
 
 template <typename T, MM2Q::Hook<T> T::*HookPtr>
-typename MM2Q::Container<T, HookPtr>::Iterator
+typename MM2Q::Container<T, HookPtr>::LockedIterator
 MM2Q::Container<T, HookPtr>::getEvictionIterator() const noexcept {
-  // we cannot use combined critical sections with folly::DistributedMutex here
-  // because the lock is held for the lifetime of the eviction iterator.  In
-  // other words, the abstraction of the iterator just does not lend itself well
-  // to combinable critical sections as the user can hold the lock for an
-  // arbitrary amount of time outside a lambda-friendly piece of code (eg. they
-  // can return the iterator from functions, pass it to functions, etc)
-  //
-  // it would be theoretically possible to refactor this interface into
-  // something like the following to allow combining
-  //
-  //    mm2q.withEvictionIterator([&](auto iterator) {
-  //      // user code
-  //    });
-  //
-  // at the time of writing it is unclear if the gains from combining are
-  // reasonable justification for the codemod required to achieve combinability
-  // as we don't expect this critical section to be the hotspot in user code.
-  // This is however subject to change at some time in the future as and when
-  // this assertion becomes false.
   LockHolder l(*lruMutex_);
-  return Iterator{std::move(l), lru_.rbegin()};
+  return LockedIterator{std::move(l), lru_.rbegin()};
+}
+
+template <typename T, MM2Q::Hook<T> T::*HookPtr>
+template <typename F>
+void MM2Q::Container<T, HookPtr>::withEvictionIterator(F&& fun) {
+  if (config_.useCombinedLockForIterators) {
+    lruMutex_->lock_combine([this, &fun]() { fun(Iterator{lru_.rbegin()}); });
+  } else {
+    LockHolder lck{*lruMutex_};
+    fun(Iterator{lru_.rbegin()});
+  }
 }
 
 template <typename T, MM2Q::Hook<T> T::*HookPtr>
@@ -462,8 +454,9 @@ void MM2Q::Container<T, HookPtr>::reconfigureLocked(const Time& currTime) {
 
 // Iterator Context Implementation
 template <typename T, MM2Q::Hook<T> T::*HookPtr>
-MM2Q::Container<T, HookPtr>::Iterator::Iterator(
-    LockHolder l, const typename LruList::Iterator& iter) noexcept
-    : LruList::Iterator(iter), l_(std::move(l)) {}
+MM2Q::Container<T, HookPtr>::LockedIterator::LockedIterator(
+    LockHolder l, const Iterator& iter) noexcept
+    : Iterator(iter), l_(std::move(l)) {}
+
 } // namespace cachelib
 } // namespace facebook

--- a/cachelib/allocator/MMLru-inl.h
+++ b/cachelib/allocator/MMLru-inl.h
@@ -212,10 +212,21 @@ bool MMLru::Container<T, HookPtr>::add(T& node) noexcept {
 }
 
 template <typename T, MMLru::Hook<T> T::*HookPtr>
-typename MMLru::Container<T, HookPtr>::Iterator
+typename MMLru::Container<T, HookPtr>::LockedIterator
 MMLru::Container<T, HookPtr>::getEvictionIterator() const noexcept {
   LockHolder l(*lruMutex_);
-  return Iterator{std::move(l), lru_.rbegin()};
+  return LockedIterator{std::move(l), lru_.rbegin()};
+}
+
+template <typename T, MMLru::Hook<T> T::*HookPtr>
+template <typename F>
+void MMLru::Container<T, HookPtr>::withEvictionIterator(F&& fun) {
+  if (config_.useCombinedLockForIterators) {
+    lruMutex_->lock_combine([this, &fun]() { fun(Iterator{lru_.rbegin()}); });
+  } else {
+    LockHolder lck{*lruMutex_};
+    fun(Iterator{lru_.rbegin()});
+  }
 }
 
 template <typename T, MMLru::Hook<T> T::*HookPtr>
@@ -360,8 +371,9 @@ void MMLru::Container<T, HookPtr>::reconfigureLocked(const Time& currTime) {
 
 // Iterator Context Implementation
 template <typename T, MMLru::Hook<T> T::*HookPtr>
-MMLru::Container<T, HookPtr>::Iterator::Iterator(
-    LockHolder l, const typename LruList::Iterator& iter) noexcept
-    : LruList::Iterator(iter), l_(std::move(l)) {}
+MMLru::Container<T, HookPtr>::LockedIterator::LockedIterator(
+    LockHolder l, const Iterator& iter) noexcept
+    : Iterator(iter), l_(std::move(l)) {}
+
 } // namespace cachelib
 } // namespace facebook

--- a/cachelib/allocator/tests/MM2QTest.cpp
+++ b/cachelib/allocator/tests/MM2QTest.cpp
@@ -43,6 +43,7 @@ TEST_F(MM2QTest, RemoveWithSmallQueues) {
 
   // trying to remove through iterator should work as expected.
   // no need of iter++ since remove will do that.
+  verifyIterationVariants(c);
   for (auto iter = c.getEvictionIterator(); iter;) {
     auto& node = *iter;
     ASSERT_TRUE(node.isInMMContainer());
@@ -54,6 +55,7 @@ TEST_F(MM2QTest, RemoveWithSmallQueues) {
       ASSERT_NE((*iter).getId(), node.getId());
     }
   }
+  verifyIterationVariants(c);
 
   ASSERT_EQ(c.getStats().size, 0);
   for (const auto& node : nodes) {
@@ -75,9 +77,9 @@ TEST_F(MM2QTest, RecordAccessWrites) {
   // ensure that nodes are updated in lru with access mode write (read) only
   // when updateOnWrite (updateOnRead) is enabled.
 
-  auto testWithAccessMode = [](Container& c_, const Nodes& nodes_,
-                               AccessMode mode, bool updateOnWrites,
-                               bool updateOnReads) {
+  auto testWithAccessMode = [this](Container& c_, const Nodes& nodes_,
+                                   AccessMode mode, bool updateOnWrites,
+                                   bool updateOnReads) {
     // accessing must at least update the update time. to do so, first set the
     // updateTime of the node to be in the past.
     const uint32_t timeInPastStart = 100;
@@ -95,6 +97,7 @@ TEST_F(MM2QTest, RecordAccessWrites) {
     for (auto itr = c_.getEvictionIterator(); itr; ++itr) {
       nodeOrderPrev.push_back(itr->getId());
     }
+    verifyIterationVariants(c_);
 
     int nAccess = 1000;
     std::set<int> accessedNodes;
@@ -122,6 +125,7 @@ TEST_F(MM2QTest, RecordAccessWrites) {
     for (auto itr = c_.getEvictionIterator(); itr; ++itr) {
       nodeOrderCurr.push_back(itr->getId());
     }
+    verifyIterationVariants(c_);
 
     if ((mode == AccessMode::kWrite && updateOnWrites) ||
         (mode == AccessMode::kRead && updateOnReads)) {
@@ -209,6 +213,7 @@ TEST_F(MM2QTest, RecordAccessWrites) {
 template <typename MMType>
 void MMTypeTest<MMType>::testIterate(std::vector<std::unique_ptr<Node>>& nodes,
                                      Container& c) {
+  verifyIterationVariants(c);
   auto it2q = c.getEvictionIterator();
   auto it = nodes.begin();
   while (it2q) {
@@ -223,6 +228,7 @@ void MMTypeTest<MMType>::testMatch(std::string expected,
                                    MMTypeTest<MMType>::Container& c) {
   int index = -1;
   std::string actual;
+  verifyIterationVariants(c);
   auto it2q = c.getEvictionIterator();
   while (it2q) {
     ++index;
@@ -692,6 +698,41 @@ TEST_F(MM2QTest, TailTrackingEnabledCheck) {
     newConfig.addExtraConfig(2);
 
     EXPECT_THROW(c.setConfig(newConfig), std::invalid_argument);
+  }
+}
+
+TEST_F(MM2QTest, CombinedLockingIteration) {
+  MM2QTest::Config config{};
+  config.useCombinedLockForIterators = true;
+  config.lruRefreshTime = 0;
+  Container c(config, {});
+  std::vector<std::unique_ptr<Node>> nodes;
+  createSimpleContainer(c, nodes);
+
+  // access to move items from cold to warm
+  for (auto& node : nodes) {
+    ASSERT_TRUE(c.recordAccess(*node, AccessMode::kRead));
+  }
+
+  // trying to remove through iterator should work as expected.
+  // no need of iter++ since remove will do that.
+  verifyIterationVariants(c);
+  for (auto iter = c.getEvictionIterator(); iter;) {
+    auto& node = *iter;
+    ASSERT_TRUE(node.isInMMContainer());
+
+    // this will move the iter.
+    c.remove(iter);
+    ASSERT_FALSE(node.isInMMContainer());
+    if (iter) {
+      ASSERT_NE((*iter).getId(), node.getId());
+    }
+  }
+  verifyIterationVariants(c);
+
+  ASSERT_EQ(c.getStats().size, 0);
+  for (const auto& node : nodes) {
+    ASSERT_FALSE(node->isInMMContainer());
   }
 }
 } // namespace cachelib

--- a/cachelib/allocator/tests/MMTinyLFUTest.cpp
+++ b/cachelib/allocator/tests/MMTinyLFUTest.cpp
@@ -42,9 +42,9 @@ TEST_F(MMTinyLFUTest, RecordAccessWrites) {
   // ensure that nodes are updated in lru with access mode write (read) only
   // when updateOnWrite (updateOnRead) is enabled.
 
-  auto testWithAccessMode = [](Container& c_, const Nodes& nodes_,
-                               AccessMode mode, bool updateOnWrites,
-                               bool updateOnReads) {
+  auto testWithAccessMode = [this](Container& c_, const Nodes& nodes_,
+                                   AccessMode mode, bool updateOnWrites,
+                                   bool updateOnReads) {
     // accessing must at least update the update time. to do so, first set the
     // updateTime of the node to be in the past.
     const uint32_t timeInPastStart = 100;
@@ -62,6 +62,7 @@ TEST_F(MMTinyLFUTest, RecordAccessWrites) {
     for (auto itr = c_.getEvictionIterator(); itr; ++itr) {
       nodeOrderPrev.push_back(itr->getId());
     }
+    verifyIterationVariants(c_);
 
     int nAccess = 1000;
     std::set<int> accessedNodes;
@@ -89,6 +90,7 @@ TEST_F(MMTinyLFUTest, RecordAccessWrites) {
     for (auto itr = c_.getEvictionIterator(); itr; ++itr) {
       nodeOrderCurr.push_back(itr->getId());
     }
+    verifyIterationVariants(c_);
 
     if ((mode == AccessMode::kWrite && updateOnWrites) ||
         (mode == AccessMode::kRead && updateOnReads)) {
@@ -170,6 +172,7 @@ TEST_F(MMTinyLFUTest, TinyLFUBasic) {
 
   auto checkTlfuConfig = [&](Container& container, std::string expected,
                              std::string context) {
+    verifyIterationVariants(container);
     auto it = container.getEvictionIterator();
     std::string actual;
     while (it) {

--- a/cachelib/benchmarks/MMTypeBench.h
+++ b/cachelib/benchmarks/MMTypeBench.h
@@ -203,10 +203,11 @@ void MMTypeBench<MMType>::benchRemoveIterator(unsigned int numNodes) {
   //
   // no need of iter++ since remove will do that.
   for (unsigned int deleted = 0; deleted < numNodes; deleted++) {
-    auto iter = c->getEvictionIterator();
-    if (iter) {
-      c->remove(iter);
-    }
+    c->withEvictionIterator([this](auto&& iter) {
+      if (iter) {
+        c->remove(iter);
+      }
+    });
   }
 }
 

--- a/cachelib/cachebench/cache/Cache.h
+++ b/cachelib/cachebench/cache/Cache.h
@@ -466,7 +466,9 @@ inline typename LruAllocator::MMConfig makeMMConfig(CacheConfig const& config) {
                                 config.lruUpdateOnWrite,
                                 config.lruUpdateOnRead,
                                 config.tryLockUpdate,
-                                static_cast<uint8_t>(config.lruIpSpec));
+                                static_cast<uint8_t>(config.lruIpSpec),
+                                0,
+                                config.useCombinedLockForIterators);
 }
 
 // LRU
@@ -480,7 +482,9 @@ inline typename Lru2QAllocator::MMConfig makeMMConfig(
                                   config.tryLockUpdate,
                                   false,
                                   config.lru2qHotPct,
-                                  config.lru2qColdPct);
+                                  config.lru2qColdPct,
+                                  0,
+                                  config.useCombinedLockForIterators);
 }
 
 } // namespace cachebench

--- a/cachelib/cachebench/util/CacheConfig.cpp
+++ b/cachelib/cachebench/util/CacheConfig.cpp
@@ -43,6 +43,7 @@ CacheConfig::CacheConfig(const folly::dynamic& configJson) {
   JSONSetVal(configJson, lruUpdateOnRead);
   JSONSetVal(configJson, tryLockUpdate);
   JSONSetVal(configJson, lruIpSpec);
+  JSONSetVal(configJson, useCombinedLockForIterators);
 
   JSONSetVal(configJson, lru2qHotPct);
   JSONSetVal(configJson, lru2qColdPct);

--- a/cachelib/cachebench/util/CacheConfig.h
+++ b/cachelib/cachebench/util/CacheConfig.h
@@ -72,6 +72,7 @@ struct CacheConfig : public JSONConfig {
   bool lruUpdateOnWrite{false};
   bool lruUpdateOnRead{true};
   bool tryLockUpdate{false};
+  bool useCombinedLockForIterators{false};
 
   // LRU param
   uint64_t lruIpSpec{0};

--- a/website/docs/Cache_Library_Architecture_Guide/RAM_cache_indexing_and_eviction.md
+++ b/website/docs/Cache_Library_Architecture_Guide/RAM_cache_indexing_and_eviction.md
@@ -114,6 +114,10 @@ It has the following major API functions:
     that can be evicted (no active handles, not moving, etc) is used (see
     `CacheAllocator<CacheTrait>::findEviction(PoolId pid, ClassId cid)` in
     `cachelib/allocator/CacheAllocator-inl.h`).
+* `withEvictionIterator`: Executes callback with eviction iterator passed as a
+    parameter. This is alternative for `getEvictionIterator` that offers possibility
+    to use combined locking. Combined locking can be turned on by setting:
+    `useCombinedLockForIterators` config option.
 
 The full API can be found in `struct Container` in
 `cachelib/allocator/MMLru.h`.  This links to MMLru, which is one of the


### PR DESCRIPTION
through withEvictionIterator function.

Also, expose the config option to enable and disable combined locking.
withEvictionIterator is implemented as an extra function, getEvictionIterator() is still there and it's behavior hasn't changed.

This is a subset of changes from: https://github.com/facebook/CacheLib/pull/172