### PR TITLE
Add missing #include directives needed for GCC 13

### DIFF
--- a/cachelib/allocator/MarginalHitsState.h
+++ b/cachelib/allocator/MarginalHitsState.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <iostream>
 #include <unordered_map>
 #include <vector>

--- a/cachelib/common/TestUtils.h
+++ b/cachelib/common/TestUtils.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <set>
 #include <string>


### PR DESCRIPTION
Fixes:

```
In file included from /builddir/build/BUILD/CacheLib-bd22b0eb79f7e2326f77a22c278c48e454882291/cachelib/../cachelib/all
ocator/MarginalHitsState.h:81,
                 from /builddir/build/BUILD/CacheLib-bd22b0eb79f7e2326f77a22c278c48e454882291/cachelib/../cachelib/all
ocator/MarginalHitsStrategy.h:19,
                 from /builddir/build/BUILD/CacheLib-bd22b0eb79f7e2326f77a22c278c48e454882291/cachelib/allocator/Margi
nalHitsStrategy.cpp:17:
/builddir/build/BUILD/CacheLib-bd22b0eb79f7e2326f77a22c278c48e454882291/cachelib/../cachelib/allocator/MarginalHitsSta
te-inl.h: In static member function 'static void facebook::cachelib::MarginalHitsState<EntityId>::updateRankingsImpl(s
td::vector<EntityId>, const std::unordered_map<EntityId, double>&, const double&, std::unordered_map<EntityId, double>
&)':
/builddir/build/BUILD/CacheLib-bd22b0eb79f7e2326f77a22c278c48e454882291/cachelib/../cachelib/allocator/MarginalHitsSta
te-inl.h:41:8: error: 'uint32_t' was not declared in this scope
   41 |   for (uint32_t i = 0; i < entities.size(); i++) {
      |        ^~~~~~~~
/builddir/build/BUILD/CacheLib-bd22b0eb79f7e2326f77a22c278c48e454882291/cachelib/../cachelib/allocator/MarginalHitsSta
te-inl.h:1:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
  +++ |+#include <cstdint>
    1 | /*
```

```
In file included from /builddir/build/BUILD/CacheLib-bd22b0eb79f7e2326f77a22c278c48e454882291/cachelib/common/TestUtils.cpp:17:
/builddir/build/BUILD/CacheLib-bd22b0eb79f7e2326f77a22c278c48e454882291/cachelib/../cachelib/common/TestUtils.h:30:53: error: 'uint64_t' has not been declared
   30 | bool eventuallyTrue(std::function<bool(void)> test, uint64_t timeoutSecs = 60);
      |                                                     ^~~~~~~~
In file included from /builddir/build/BUILD/CacheLib-bd22b0eb79f7e2326f77a22c278c48e454882291/cachelib/common/TestUtils.cpp:17:
/builddir/build/BUILD/CacheLib-bd22b0eb79f7e2326f77a22c278c48e454882291/cachelib/../cachelib/common/TestUtils.h:30:53: error: 'uint64_t' has not been declared
   30 | bool eventuallyTrue(std::function<bool(void)> test, uint64_t timeoutSecs = 60);
      |                                                     ^~~~~~~~
```
