### PR TITLE
fix compilation two issues

### DIFF
--- a/contrib/build-package.sh
+++ b/contrib/build-package.sh
@@ -259,7 +259,7 @@ test "$debug_build" \
 MAKE_PARAMS=
 test "$verbose" && MAKE_PARAMS="$MAKE_PARAMS VERBOSE=YES"
 
-JOBS=$(nproc --ignore 1)
+JOBS=$(nproc --all --ignore 1)
 test "$many_jobs" && MAKE_PARAMS="$MAKE_PARAMS -j$JOBS"
 
 

--- a/contrib/prerequisites-ubuntu18.sh
+++ b/contrib/prerequisites-ubuntu18.sh
@@ -18,7 +18,6 @@ sudo apt-get install -y \
   build-essential \
   git \
   g++ \
-  cmake \
   bison flex \
   libboost-all-dev \
   libevent-dev \

--- a/contrib/prerequisites-ubuntu18.sh
+++ b/contrib/prerequisites-ubuntu18.sh
@@ -18,6 +18,7 @@ sudo apt-get install -y \
   build-essential \
   git \
   g++ \
+  cmake \
   bison flex \
   libboost-all-dev \
   libevent-dev \


### PR DESCRIPTION
1. remove cmake from Ubuntu apt installation because the cmake installed from apt (both Ubuntu18 and Ubuntu20) is too old to be used, and the new cmake from apt shadows existing cmake binary. 
2. current compilation cannot use multiple cores even though `-j` is specified due to a bug in using `nproc`. 