### PR TITLE
Pin fmt version at 8.0.1

### DIFF
--- a/contrib/build-package.sh
+++ b/contrib/build-package.sh
@@ -160,6 +160,7 @@ case "$1" in
     REPODIR=cachelib/external/$NAME
     SRCDIR=$REPODIR
     external_git_clone=yes
+    external_git_tag="8.0.1"
     cmake_custom_params="-DBUILD_SHARED_LIBS=ON"
     if test "$build_tests" = "yes" ; then
         cmake_custom_params="$cmake_custom_params -DFMT_TEST=YES"


### PR DESCRIPTION
Change build script to pin fmt version to same as folly's to minimize future breaks.

**Test Plan:** Built successfully on a fresh clone of CacheLib. (Also had to change `external_git_branch=dev` for zstd to deal with the cmake/zstd issue in #194, but that should resolve when gets merged into release)

**Context:** OSS build broke since 3-5 Jan 2023, likely due to changes in folly. While switching to v9.1.0 or 9.0.0 fixes the issue at hand, it seems sensible to match folly, which specifies fmt v8.0.1: https://github.com/facebook/folly/blob/main/build/fbcode_builder/manifests/fmt

> #62 @agordon: For the other packages, you'll notice we do use a specific git tag or branch… I notice `fmt` is an exception - not pinned to a specific git tag or revision - likely an omission that can be fixed.

Related CacheLib issues: #186, #189, #107, #97, #62
Possibly related CacheLib commit: 67cc11ad6f5fb7b1e1948513292ef00edee34f5e

Last working (Jan 3): https://github.com/facebook/CacheLib/actions/runs/3826992478
First failed (Jan 5): https://github.com/facebook/CacheLib/actions/runs/3844002307/jobs/6546742348
Error: `error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt`