### PR TITLE
Add missing numa deps for fedora, rocky, arch

### DIFF
--- a/contrib/prerequisites-arch.sh
+++ b/contrib/prerequisites-arch.sh
@@ -19,4 +19,5 @@ sudo pacman -S --needed --noconfirm cmake \
   boost \
   double-conversion \
   libdwarf \
+  numactl \
   libsodium

--- a/contrib/prerequisites-fedora32.sh
+++ b/contrib/prerequisites-fedora32.sh
@@ -21,6 +21,7 @@ sudo dnf -y install bison flex patch bzip2 cmake \
   zlib-devel lz4-devel xz-devel bzip2-devel \
   jemalloc-devel snappy-devel libsodium-devel libdwarf-devel libaio-devel \
   gmock-devel gflags-devel gtest gtest-devel \
+  numactl-devel \
   fmt fmt-devel
 
 # DO NOT INSTALL glog-devel - need to build from source for the glog-*.cmake files

--- a/contrib/prerequisites-fedora34.sh
+++ b/contrib/prerequisites-fedora34.sh
@@ -19,4 +19,5 @@ sudo dnf -y install bison flex patch bzip2 cmake \
   double-conversion double-conversion-devel make g++ \
   boost-devel libevent-devel openssl-devel libunwind-devel \
   zlib-devel lz4-devel xz-devel bzip2-devel \
-  jemalloc-devel snappy-devel libsodium-devel libdwarf-devel libaio-devel
+  jemalloc-devel snappy-devel libsodium-devel libdwarf-devel libaio-devel \
+  numactl-devel

--- a/contrib/prerequisites-rocky9.sh
+++ b/contrib/prerequisites-rocky9.sh
@@ -38,7 +38,8 @@ sudo dnf install -y \
   jemalloc-devel \
   libsodium-devel \
   libaio-devel \
-  binutils-devel
+  binutils-devel \
+  numactl-devel
 
 
 sudo dnf install -y \


### PR DESCRIPTION
Fix OSS builds by adding numa deps to build files. Currently some fail on missing `numa.h`.

Context: #161 added the dependencies to the centOS, debian, and ubuntu18 build files. The PR was opened in Sep 2022 but only landed in Dec 2022, and so probably missed out on the fedora, rocky and arch build files which were added in-between those dates. Having had those build actions run on PRs would have caught this (currently, they are only scheduled.)

Test Plan: Github Actions builds (ideally, #198 would be landed first.) I've checked that those packages exist for the respective repositories but didn't run them myself.