### PR TITLE
Run Github Actions on pull requests

### DIFF
--- a/.github/workflows/build-cachelib-centos-8-1.yml
+++ b/.github/workflows/build-cachelib-centos-8-1.yml
@@ -14,6 +14,7 @@
 name: build-cachelib-centos-8-1
 on:
 #  push:
+  pull_request:
   schedule:
      - cron:  '0 11 * * 1,3,5'
 jobs:

--- a/.github/workflows/build-cachelib-centos-8-5.yml
+++ b/.github/workflows/build-cachelib-centos-8-5.yml
@@ -14,6 +14,7 @@
 name: build-cachelib-centos-8.5
 on:
 #   push:
+  pull_request:
   schedule:
      - cron:  '0 9 * * *'
 jobs:

--- a/.github/workflows/build-cachelib-debian-10.yml
+++ b/.github/workflows/build-cachelib-debian-10.yml
@@ -14,6 +14,7 @@
 name: build-cachelib-debian-10
 on:
 #  push:
+  pull_request:
   schedule:
      - cron:  '0 13 * * *'
 jobs:

--- a/.github/workflows/build-cachelib-fedora-36.yml
+++ b/.github/workflows/build-cachelib-fedora-36.yml
@@ -14,6 +14,7 @@
 name: build-cachelib-fedora-36
 on:
 #  push:
+  pull_request:
   schedule:
      - cron:  '0 19 * * *'
 jobs:

--- a/.github/workflows/build-cachelib-rockylinux-8.yml
+++ b/.github/workflows/build-cachelib-rockylinux-8.yml
@@ -14,6 +14,7 @@
 name: build-cachelib-rockylinux-8.6
 on:
 #   push:
+  pull_request:
   schedule:
      - cron:  '0 15 * * 2,4,6'
 jobs:

--- a/.github/workflows/build-cachelib-rockylinux-9.yml
+++ b/.github/workflows/build-cachelib-rockylinux-9.yml
@@ -14,6 +14,7 @@
 name: build-cachelib-rockylinux-9.0
 on:
 #   push:
+  pull_request:
   schedule:
      - cron:  '0 17 * * *'
 jobs:

--- a/.github/workflows/build-cachelib-ubuntu-18.yml
+++ b/.github/workflows/build-cachelib-ubuntu-18.yml
@@ -19,6 +19,7 @@
 name: build-cachelib-ubuntu-18
 on:
 #  push:
+  pull_request:
   schedule:
     - cron:  '0 5 * * 2,4,6'
 jobs:

--- a/.github/workflows/build-cachelib-ubuntu-20.yml
+++ b/.github/workflows/build-cachelib-ubuntu-20.yml
@@ -15,6 +15,7 @@
 name: build-cachelib-ubuntu-20
 on:
 #  push:
+  pull_request:
   schedule:
     - cron:  '0 5 * * 1,3,5'
 jobs:

--- a/.github/workflows/build-cachelib-ubuntu-22.yml
+++ b/.github/workflows/build-cachelib-ubuntu-22.yml
@@ -15,6 +15,7 @@
 name: build-cachelib-ubuntu-22
 on:
 #  push:
+  pull_request:
   schedule:
     - cron:  '0 7 * * *'
 jobs:


### PR DESCRIPTION
Run GitHub action builds on every pull request, in addition to currently daily scheduled runs.

Benefit: avoid accidentally breaking other OS builds. This would have caught #197.
This triggers whenever PRs are opened or when commits are added to a PR. 

Frequency of PRs (total of 76 PRs over last 18 months since CacheLib was open-sourced) is much less than frequency  of daily scheduled builds, so this shouldn't add too many builds overall.