### PR TITLE
Fix Debian GitHub build & zstd CMake error

### DIFF
--- a/.github/workflows/build-cachelib-debian-10.yml
+++ b/.github/workflows/build-cachelib-debian-10.yml
@@ -52,6 +52,9 @@ jobs:
           g++ - || true
       - name: "checkout sources"
         uses: actions/checkout@v2
+      - name: "Add Git safe directory"
+        # Workaround for Docker image bug (GitHub issue #199).
+        run: git config --system --add safe.directory /__w/CacheLib/CacheLib
       - name: "Install Prerequisites"
         run: ./contrib/build.sh -S -B
       - name: "Test: update-submodules"

--- a/.github/workflows/build-cachelib-debian-10.yml
+++ b/.github/workflows/build-cachelib-debian-10.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v2
       - name: "Add Git safe directory"
         # Workaround for Docker image bug (GitHub issue #199).
-        run: git config --system --add safe.directory /__w/CacheLib/CacheLib
+        run: git config --system --add safe.directory $GITHUB_WORKSPACE
       - name: "Install Prerequisites"
         run: ./contrib/build.sh -S -B
       - name: "Test: update-submodules"

--- a/contrib/build-package.sh
+++ b/contrib/build-package.sh
@@ -102,13 +102,12 @@ test "$#" -eq 0 \
     && die "missing dependancy name to build. See -h for help"
 
 ######################################
-## Check which dependecy was requested
+## Check which dependency was requested
 ######################################
 
 external_git_clone=
 external_git_branch=
 external_git_tag=
-external_git_commit=
 update_submodules=
 cmake_custom_params=
 
@@ -176,7 +175,10 @@ case "$1" in
     REPODIR=cachelib/external/$NAME
     SRCDIR=$REPODIR/build/cmake
     external_git_clone=yes
-    external_git_commit=8420502e
+    # Previously, we pinned to release branch. v1.5.4 needed
+    # CMake >= 3.18, later reverted. While waiting for v1.5.5,
+    # pin to the fix: https://github.com/facebook/zstd/pull/3510
+    external_git_tag=8420502e
     if test "$build_tests" = "yes" ; then
         cmake_custom_params="-DZSTD_BUILD_TESTS=ON"
     else
@@ -308,12 +310,9 @@ if test "$source" ; then
     fi
 
 
-    # switch to specific branch/tag/commit if needed
-    if test "$external_git_commit" ; then
-        ( cd "$REPODIR" \
-           && git checkout --force "$external_git_commit" ) \
-           || die "failed to checkout commit $external_git_commit in $REPODIR"
-    elif test "$external_git_branch" ; then
+    # switch to specific branch/tag if needed
+    # external_git_tag can also be used for commits
+    if test "$external_git_branch" ; then
         ( cd "$REPODIR" \
            && git checkout --force "origin/$external_git_branch" ) \
            || die "failed to checkout branch $external_git_branch in $REPODIR"

--- a/contrib/build-package.sh
+++ b/contrib/build-package.sh
@@ -108,6 +108,7 @@ test "$#" -eq 0 \
 external_git_clone=
 external_git_branch=
 external_git_tag=
+external_git_commit=
 update_submodules=
 cmake_custom_params=
 
@@ -175,7 +176,7 @@ case "$1" in
     REPODIR=cachelib/external/$NAME
     SRCDIR=$REPODIR/build/cmake
     external_git_clone=yes
-    external_git_branch=release
+    external_git_commit=8420502e
     if test "$build_tests" = "yes" ; then
         cmake_custom_params="-DZSTD_BUILD_TESTS=ON"
     else
@@ -307,8 +308,12 @@ if test "$source" ; then
     fi
 
 
-    # switch to specific branch/tag if needed
-    if test "$external_git_branch" ; then
+    # switch to specific branch/tag/commit if needed
+    if test "$external_git_commit" ; then
+        ( cd "$REPODIR" \
+           && git checkout --force "$external_git_commit" ) \
+           || die "failed to checkout commit $external_git_commit in $REPODIR"
+    elif test "$external_git_branch" ; then
         ( cd "$REPODIR" \
            && git checkout --force "origin/$external_git_branch" ) \
            || die "failed to checkout branch $external_git_branch in $REPODIR"

--- a/contrib/build-package.sh
+++ b/contrib/build-package.sh
@@ -107,6 +107,7 @@ test "$#" -eq 0 \
 
 external_git_clone=
 external_git_branch=
+# external_git_tag can also be used for commit hashes
 external_git_tag=
 update_submodules=
 cmake_custom_params=
@@ -311,7 +312,6 @@ if test "$source" ; then
 
 
     # switch to specific branch/tag if needed
-    # external_git_tag can also be used for commits
     if test "$external_git_branch" ; then
         ( cd "$REPODIR" \
            && git checkout --force "origin/$external_git_branch" ) \


### PR DESCRIPTION
1. Workaround for Debian Docker image bug that is breaking Debian build on GitHub (Explicitly mark Git repo as safe).
2. Pin zstd to a commit that resolves problems with older CMakes (note: affects all OSes, not just Debian)

Context for 1: In latest Debian Docker image , there is a regression that affects the checkout action.

From https://github.com/actions/checkout/issues/1169:
> - Checkout runs, and runs /usr/bin/git config --global --add safe.directory <path>
> - The global .gitconfig does not exist
> - Any calls to git remain unsafe/dubious

The suggested workaround was to use --system instead of --global.

Test Plan: See if GitHub Action Debian build is fixed.