### PR TITLE
Initial framework for background item eviction/promotion

### DIFF
--- a/cachelib/allocator/BackgroundMover-inl.h
+++ b/cachelib/allocator/BackgroundMover-inl.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Intel and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace facebook {
+namespace cachelib {
+
+template <typename CacheT>
+BackgroundMover<CacheT>::BackgroundMover(
+    Cache& cache,
+    std::shared_ptr<BackgroundMoverStrategy> strategy,
+    MoverDir direction)
+    : cache_(cache), strategy_(strategy), direction_(direction) {
+  if (direction_ == MoverDir::Evict) {
+    moverFunc = BackgroundMoverAPIWrapper<CacheT>::traverseAndEvictItems;
+
+  } else if (direction_ == MoverDir::Promote) {
+    moverFunc = BackgroundMoverAPIWrapper<CacheT>::traverseAndPromoteItems;
+  }
+}
+
+template <typename CacheT>
+BackgroundMover<CacheT>::~BackgroundMover() {
+  stop(std::chrono::seconds(0));
+}
+
+template <typename CacheT>
+void BackgroundMover<CacheT>::work() {
+  try {
+    checkAndRun();
+  } catch (const std::exception& ex) {
+    XLOGF(ERR, "BackgroundMover interrupted due to exception: {}", ex.what());
+  }
+}
+
+template <typename CacheT>
+void BackgroundMover<CacheT>::setAssignedMemory(
+    std::vector<MemoryDescriptorType>&& assignedMemory) {
+  XLOG(INFO, "Class assigned to background worker:");
+  for (auto [pid, cid] : assignedMemory) {
+    XLOGF(INFO, "Pid: {}, Cid: {}", pid, cid);
+  }
+
+  mutex_.lock_combine([this, &assignedMemory] {
+    this->assignedMemory_ = std::move(assignedMemory);
+  });
+}
+
+// Look for classes that exceed the target memory capacity
+// and return those for eviction
+template <typename CacheT>
+void BackgroundMover<CacheT>::checkAndRun() {
+  auto assignedMemory = mutex_.lock_combine([this] { return assignedMemory_; });
+
+  unsigned int moves = 0;
+  auto batches = strategy_->calculateBatchSizes(cache_, assignedMemory);
+
+  for (size_t i = 0; i < batches.size(); i++) {
+    const auto [pid, cid] = assignedMemory[i];
+    const auto batch = batches[i];
+
+    if (batch == 0) {
+      continue;
+    }
+
+    // try moving BATCH items from the class in order to reach free target
+    auto moved = moverFunc(cache_, pid, cid, batch);
+    moves += moved;
+    movesPerClass_[pid][cid] += moved;
+    totalBytesMoved_.add(moved * cache_.getPool(pid).getAllocSizes()[cid]);
+  }
+
+  numTraversals_.inc();
+  numMovedItems_.add(moves);
+}
+
+template <typename CacheT>
+BackgroundMoverStats BackgroundMover<CacheT>::getStats() const noexcept {
+  BackgroundMoverStats stats;
+  stats.numMovedItems = numMovedItems_.get();
+  stats.runCount = numTraversals_.get();
+  stats.totalBytesMoved = totalBytesMoved_.get();
+
+  return stats;
+}
+
+template <typename CacheT>
+std::map<PoolId, std::map<ClassId, uint64_t>>
+BackgroundMover<CacheT>::getClassStats() const noexcept {
+  return movesPerClass_;
+}
+
+template <typename CacheT>
+size_t BackgroundMover<CacheT>::workerId(PoolId pid,
+                                         ClassId cid,
+                                         size_t numWorkers) {
+  XDCHECK(numWorkers);
+
+  // TODO: came up with some better sharding (use hashing?)
+  return (pid + cid) % numWorkers;
+}
+
+} // namespace cachelib
+} // namespace facebook

--- a/cachelib/allocator/BackgroundMover.h
+++ b/cachelib/allocator/BackgroundMover.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Intel and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "cachelib/allocator/BackgroundMoverStrategy.h"
+#include "cachelib/allocator/CacheStats.h"
+#include "cachelib/common/AtomicCounter.h"
+#include "cachelib/common/PeriodicWorker.h"
+
+namespace facebook {
+namespace cachelib {
+
+// wrapper that exposes the private APIs of CacheType that are specifically
+// needed for the cache api
+template <typename C>
+struct BackgroundMoverAPIWrapper {
+  static size_t traverseAndEvictItems(C& cache,
+                                      unsigned int pid,
+                                      unsigned int cid,
+                                      size_t batch) {
+    return cache.traverseAndEvictItems(pid, cid, batch);
+  }
+
+  static size_t traverseAndPromoteItems(C& cache,
+                                        unsigned int pid,
+                                        unsigned int cid,
+                                        size_t batch) {
+    return cache.traverseAndPromoteItems(pid, cid, batch);
+  }
+};
+
+enum class MoverDir { Evict = 0, Promote };
+
+// Periodic worker that evicts items from tiers in batches
+// The primary aim is to reduce insertion times for new items in the
+// cache
+template <typename CacheT>
+class BackgroundMover : public PeriodicWorker {
+ public:
+  using Cache = CacheT;
+  // @param cache               the cache interface
+  // @param strategy            the stragey class that defines how objects are
+  // moved (promoted vs. evicted and how much)
+  BackgroundMover(Cache& cache,
+                  std::shared_ptr<BackgroundMoverStrategy> strategy,
+                  MoverDir direction_);
+
+  ~BackgroundMover() override;
+
+  BackgroundMoverStats getStats() const noexcept;
+  std::map<PoolId, std::map<ClassId, uint64_t>> getClassStats() const noexcept;
+
+  void setAssignedMemory(std::vector<MemoryDescriptorType>&& assignedMemory);
+
+  // return id of the worker responsible for promoting/evicting from particlar
+  // pool and allocation calss (id is in range [0, numWorkers))
+  static size_t workerId(PoolId pid, ClassId cid, size_t numWorkers);
+
+ private:
+  std::map<PoolId, std::map<ClassId, uint64_t>> movesPerClass_;
+  // cache allocator's interface for evicting
+  using Item = typename Cache::Item;
+
+  Cache& cache_;
+  std::shared_ptr<BackgroundMoverStrategy> strategy_;
+  MoverDir direction_;
+
+  std::function<size_t(Cache&, unsigned int, unsigned int, size_t)> moverFunc;
+
+  // implements the actual logic of running the background evictor
+  void work() override final;
+  void checkAndRun();
+
+  AtomicCounter numMovedItems_{0};
+  AtomicCounter numTraversals_{0};
+  AtomicCounter totalBytesMoved_{0};
+
+  std::vector<MemoryDescriptorType> assignedMemory_;
+  folly::DistributedMutex mutex_;
+};
+} // namespace cachelib
+} // namespace facebook
+
+#include "cachelib/allocator/BackgroundMover-inl.h"

--- a/cachelib/allocator/BackgroundMoverStrategy.h
+++ b/cachelib/allocator/BackgroundMoverStrategy.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "cachelib/allocator/Cache.h"
+
+namespace facebook {
+namespace cachelib {
+
+struct MemoryDescriptorType {
+  MemoryDescriptorType(PoolId pid, ClassId cid) : pid_(pid), cid_(cid) {}
+  PoolId pid_;
+  ClassId cid_;
+};
+
+// Base class for background eviction strategy.
+class BackgroundMoverStrategy {
+ public:
+  // Calculate how many items should be moved by the background mover
+  //
+  // @param cache   Cache allocator that implements CacheBase
+  // @param acVec   vector of memory descriptors for which batch sizes should
+  //                be calculated
+  //
+  // @return vector of batch sizes, where each element in the vector specifies
+  //         batch size for the memory descriptor in acVec
+  virtual std::vector<size_t> calculateBatchSizes(
+      const CacheBase& cache, std::vector<MemoryDescriptorType> acVec) = 0;
+};
+
+} // namespace cachelib
+} // namespace facebook

--- a/cachelib/allocator/CMakeLists.txt
+++ b/cachelib/allocator/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library (cachelib_allocator
     CCacheManager.cpp
     ContainerTypes.cpp
     FreeMemStrategy.cpp
+    FreeThresholdStrategy.cpp
     HitsPerSlabStrategy.cpp
     LruTailAgeStrategy.cpp
     MarginalHitsOptimizeStrategy.cpp

--- a/cachelib/allocator/CacheAllocator.h
+++ b/cachelib/allocator/CacheAllocator.h
@@ -38,6 +38,7 @@
 #include <folly/Range.h>
 #pragma GCC diagnostic pop
 
+#include "cachelib/allocator/BackgroundMover.h"
 #include "cachelib/allocator/CCacheManager.h"
 #include "cachelib/allocator/Cache.h"
 #include "cachelib/allocator/CacheAllocatorConfig.h"
@@ -710,6 +711,12 @@ class CacheAllocator : public CacheBase {
   // @return    the full usable size for this item
   uint32_t getUsableSize(const Item& item) const;
 
+  // create memory assignment to bg workers
+  auto createBgWorkerMemoryAssignments(size_t numWorkers);
+
+  // whether bg worker should be woken
+  bool shouldWakeupBgEvictor(PoolId pid, ClassId cid);
+
   // Get a random item from memory
   // This is useful for profiling and sampling cachelib managed memory
   //
@@ -1054,6 +1061,26 @@ class CacheAllocator : public CacheBase {
   bool startNewReaper(std::chrono::milliseconds interval,
                       util::Throttler::Config reaperThrottleConfig);
 
+  // start background promoter, starting/stopping of this worker
+  // should not be done concurrently with addPool
+  // @param interval                the period this worker fires
+  // @param strategy                strategy to promote items
+  // @param threads                 number of threads used by the worker
+  bool startNewBackgroundPromoter(
+      std::chrono::milliseconds interval,
+      std::shared_ptr<BackgroundMoverStrategy> strategy,
+      size_t threads);
+
+  // start background evictor, starting/stopping of this worker
+  // should not be done concurrently with addPool
+  // @param interval                the period this worker fires
+  // @param strategy                strategy to evict items
+  // @param threads                 number of threads used by the worker
+  bool startNewBackgroundEvictor(
+      std::chrono::milliseconds interval,
+      std::shared_ptr<BackgroundMoverStrategy> strategy,
+      size_t threads);
+
   // Stop existing workers with a timeout
   bool stopPoolRebalancer(std::chrono::seconds timeout = std::chrono::seconds{
                               0});
@@ -1062,6 +1089,10 @@ class CacheAllocator : public CacheBase {
                              0});
   bool stopMemMonitor(std::chrono::seconds timeout = std::chrono::seconds{0});
   bool stopReaper(std::chrono::seconds timeout = std::chrono::seconds{0});
+  bool stopBackgroundEvictor(
+      std::chrono::seconds timeout = std::chrono::seconds{0});
+  bool stopBackgroundPromoter(
+      std::chrono::seconds timeout = std::chrono::seconds{0});
 
   // Set pool optimization to either true or false
   //
@@ -1417,6 +1448,7 @@ class CacheAllocator : public CacheBase {
   // @param creationTime    Timestamp when this item was created
   // @param expiryTime      set an expiry timestamp for the item (0 means no
   //                        expiration time).
+  // @param fromBgThread    whether this is called from BG thread
   //
   // @return      the handle for the item or an invalid handle(nullptr) if the
   //              allocation failed. Allocation can fail if one such
@@ -1430,7 +1462,8 @@ class CacheAllocator : public CacheBase {
                                Key key,
                                uint32_t size,
                                uint32_t creationTime,
-                               uint32_t expiryTime);
+                               uint32_t expiryTime,
+                               bool fromBgThread = false);
 
   // Allocate a chained item
   //
@@ -1845,6 +1878,22 @@ class CacheAllocator : public CacheBase {
     stats().numReaperSkippedSlabs.add(slabsSkipped);
   }
 
+  // exposed for the background evictor to iterate through the memory and evict
+  // in batch. This should improve insertion path for tiered memory config
+  size_t traverseAndEvictItems(unsigned int pid,
+                               unsigned int cid,
+                               size_t batch) {
+    throw std::runtime_error("Not supported yet!");
+  }
+
+  // exposed for the background promoter to iterate through the memory and
+  // promote in batch. This should improve find latency
+  size_t traverseAndPromoteItems(unsigned int pid,
+                                 unsigned int cid,
+                                 size_t batch) {
+    throw std::runtime_error("Not supported yet!");
+  }
+
   // returns true if nvmcache is enabled and we should write this item to
   // nvmcache.
   bool shouldWriteToNvmCache(const Item& item);
@@ -1993,6 +2042,44 @@ class CacheAllocator : public CacheBase {
                      : false;
   }
 
+  // returns the background mover stats
+  BackgroundMoverStats getBackgroundMoverStats(MoverDir direction) const {
+    auto stats = BackgroundMoverStats{};
+    if (direction == MoverDir::Evict) {
+      for (auto& bg : backgroundEvictor_)
+        stats += bg->getStats();
+    } else if (direction == MoverDir::Promote) {
+      for (auto& bg : backgroundPromoter_)
+        stats += bg->getStats();
+    }
+    return stats;
+  }
+
+  std::map<PoolId, std::map<ClassId, uint64_t>> getBackgroundMoverClassStats(
+      MoverDir direction) const {
+    std::map<PoolId, std::map<ClassId, uint64_t>> stats;
+
+    if (direction == MoverDir::Evict) {
+      for (auto& bg : backgroundEvictor_) {
+        for (auto& pid : bg->getClassStats()) {
+          for (auto& cid : pid.second) {
+            stats[pid.first][cid.first] += cid.second;
+          }
+        }
+      }
+    } else if (direction == MoverDir::Promote) {
+      for (auto& bg : backgroundPromoter_) {
+        for (auto& pid : bg->getClassStats()) {
+          for (auto& cid : pid.second) {
+            stats[pid.first][cid.first] += cid.second;
+          }
+        }
+      }
+    }
+
+    return stats;
+  }
+
   // BEGIN private members
 
   // Whether the memory allocator for this cache allocator was created on shared
@@ -2073,6 +2160,10 @@ class CacheAllocator : public CacheBase {
   // free memory monitor
   std::unique_ptr<MemoryMonitor> memMonitor_;
 
+  // background evictor
+  std::vector<std::unique_ptr<BackgroundMover<CacheT>>> backgroundEvictor_;
+  std::vector<std::unique_ptr<BackgroundMover<CacheT>>> backgroundPromoter_;
+
   // check whether a pool is a slabs pool
   std::array<bool, MemoryPoolManager::kMaxPools> isCompactCachePool_{};
 
@@ -2117,6 +2208,7 @@ class CacheAllocator : public CacheBase {
   // Make this friend to give access to acquire and release
   friend ReadHandle;
   friend ReaperAPIWrapper<CacheT>;
+  friend BackgroundMoverAPIWrapper<CacheT>;
   friend class CacheAPIWrapperForNvm<CacheT>;
   friend class FbInternalRuntimeUpdateWrapper<CacheT>;
   friend class objcache2::ObjectCache<CacheT>;

--- a/cachelib/allocator/CacheStats.h
+++ b/cachelib/allocator/CacheStats.h
@@ -300,6 +300,26 @@ struct RebalancerStats {
   uint64_t avgPickTimeMs{0};
 };
 
+// Mover Stats
+struct BackgroundMoverStats {
+  // the number of items this worker moved by looking at pools/classes stats
+  uint64_t numMovedItems{0};
+  // number of times we went executed the thread //TODO: is this def correct?
+  uint64_t runCount{0};
+  // total number of classes
+  uint64_t totalClasses{0};
+  // eviction size
+  uint64_t totalBytesMoved{0};
+
+  BackgroundMoverStats& operator+=(const BackgroundMoverStats& rhs) {
+    numMovedItems += rhs.numMovedItems;
+    runCount += rhs.runCount;
+    totalClasses += rhs.totalClasses;
+    totalBytesMoved += rhs.totalBytesMoved;
+    return *this;
+  }
+};
+
 // CacheMetadata type to export
 struct CacheMetadata {
   // allocator_version
@@ -320,6 +340,11 @@ struct Stats;
 // Stats that apply globally in cache and
 // the ones that are aggregated over all pools
 struct GlobalCacheStats {
+  // background eviction stats
+  BackgroundMoverStats evictionStats;
+
+  BackgroundMoverStats promotionStats;
+
   // number of calls to CacheAllocator::find
   uint64_t numCacheGets{0};
 

--- a/cachelib/allocator/FreeThresholdStrategy.cpp
+++ b/cachelib/allocator/FreeThresholdStrategy.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Intel and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cachelib/allocator/FreeThresholdStrategy.h"
+
+#include <folly/logging/xlog.h>
+
+namespace facebook {
+namespace cachelib {
+
+FreeThresholdStrategy::FreeThresholdStrategy(double lowEvictionAcWatermark,
+                                             double highEvictionAcWatermark,
+                                             uint64_t maxEvictionBatch,
+                                             uint64_t minEvictionBatch)
+    : lowEvictionAcWatermark(lowEvictionAcWatermark),
+      highEvictionAcWatermark(highEvictionAcWatermark),
+      maxEvictionBatch(maxEvictionBatch),
+      minEvictionBatch(minEvictionBatch) {}
+
+std::vector<size_t> FreeThresholdStrategy::calculateBatchSizes(
+    const CacheBase& cache, std::vector<MemoryDescriptorType> acVec) {
+  throw std::runtime_error("Not supported yet!");
+}
+
+} // namespace cachelib
+} // namespace facebook

--- a/cachelib/allocator/FreeThresholdStrategy.h
+++ b/cachelib/allocator/FreeThresholdStrategy.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "cachelib/allocator/BackgroundMoverStrategy.h"
+#include "cachelib/allocator/Cache.h"
+
+namespace facebook {
+namespace cachelib {
+
+// Free threshold strategy for background promotion worker.
+// This strategy tries to keep certain percent of memory free
+// at all times.
+class FreeThresholdStrategy : public BackgroundMoverStrategy {
+ public:
+  FreeThresholdStrategy(double lowEvictionAcWatermark,
+                        double highEvictionAcWatermark,
+                        uint64_t maxEvictionBatch,
+                        uint64_t minEvictionBatch);
+  ~FreeThresholdStrategy() {}
+
+  std::vector<size_t> calculateBatchSizes(
+      const CacheBase& cache, std::vector<MemoryDescriptorType> acVecs);
+
+ private:
+  double lowEvictionAcWatermark{2.0};
+  double highEvictionAcWatermark{5.0};
+  uint64_t maxEvictionBatch{40};
+  uint64_t minEvictionBatch{5};
+};
+
+} // namespace cachelib
+} // namespace facebook

--- a/cachelib/allocator/PromotionStrategy.h
+++ b/cachelib/allocator/PromotionStrategy.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "cachelib/allocator/BackgroundMoverStrategy.h"
+#include "cachelib/allocator/Cache.h"
+
+namespace facebook {
+namespace cachelib {
+
+// Strategy for background promotion worker.
+class PromotionStrategy : public BackgroundMoverStrategy {
+ public:
+  PromotionStrategy(uint64_t promotionAcWatermark,
+                    uint64_t maxPromotionBatch,
+                    uint64_t minPromotionBatch)
+      : promotionAcWatermark(promotionAcWatermark),
+        maxPromotionBatch(maxPromotionBatch),
+        minPromotionBatch(minPromotionBatch) {}
+  ~PromotionStrategy() {}
+
+  std::vector<size_t> calculateBatchSizes(
+      const CacheBase& cache, std::vector<MemoryDescriptorType> acVec) {
+    return {};
+  }
+
+ private:
+  double promotionAcWatermark{4.0};
+  uint64_t maxPromotionBatch{40};
+  uint64_t minPromotionBatch{5};
+};
+
+} // namespace cachelib
+} // namespace facebook

--- a/cachelib/allocator/tests/MMTypeTest.h
+++ b/cachelib/allocator/tests/MMTypeTest.h
@@ -147,7 +147,9 @@ class MMTypeTest : public testing::Test {
   void testRecordAccessBasic(Config c);
   void testSerializationBasic(Config c);
   void testIterate(std::vector<std::unique_ptr<Node>>& nodes, Container& c);
+  void testIterateHot(std::vector<std::unique_ptr<Node>>& nodes, Container& c);
   void testMatch(std::string expected, Container& c);
+  void testMatchHot(std::string expected, Container& c);
   size_t getListSize(const Container& c, typename MMType::LruType list);
   void verifyIterationVariants(Container& c);
 };

--- a/cachelib/cachebench/cache/Cache-inl.h
+++ b/cachelib/cachebench/cache/Cache-inl.h
@@ -665,6 +665,15 @@ Stats Cache<Allocator>::getStats() const {
   ret.allocAttempts = cacheStats.allocAttempts;
   ret.allocFailures = cacheStats.allocFailures;
 
+  ret.backgndEvicStats.nEvictedItems = cacheStats.evictionStats.numMovedItems;
+  ret.backgndEvicStats.nTraversals = cacheStats.evictionStats.runCount;
+  ret.backgndEvicStats.nClasses = cacheStats.evictionStats.totalClasses;
+  ret.backgndEvicStats.evictionSize = cacheStats.evictionStats.totalBytesMoved;
+
+  ret.backgndPromoStats.nPromotedItems =
+      cacheStats.promotionStats.numMovedItems;
+  ret.backgndPromoStats.nTraversals = cacheStats.promotionStats.runCount;
+
   ret.numCacheGets = cacheStats.numCacheGets;
   ret.numCacheGetMiss = cacheStats.numCacheGetMiss;
   ret.numCacheEvictions = cacheStats.numCacheEvictions;
@@ -711,6 +720,11 @@ Stats Cache<Allocator>::getStats() const {
   if (config_.printNvmCounters) {
     ret.nvmCounters = cache_->getNvmCacheStatsMap().toMap();
   }
+
+  ret.backgroundEvictionClasses =
+      cache_->getBackgroundMoverClassStats(MoverDir::Evict);
+  ret.backgroundPromotionClasses =
+      cache_->getBackgroundMoverClassStats(MoverDir::Promote);
 
   // nvm stats from navy
   if (!isRamOnly() && !navyStats.empty()) {

--- a/cachelib/cachebench/cache/CacheStats.h
+++ b/cachelib/cachebench/cache/CacheStats.h
@@ -26,7 +26,33 @@ DECLARE_string(report_ac_memory_usage_stats);
 namespace facebook {
 namespace cachelib {
 namespace cachebench {
+
+struct BackgroundEvictionStats {
+  // the number of items this worker evicted by looking at pools/classes stats
+  uint64_t nEvictedItems{0};
+
+  // number of times we went executed the thread //TODO: is this def correct?
+  uint64_t nTraversals{0};
+
+  // number of classes
+  uint64_t nClasses{0};
+
+  // size of evicted items
+  uint64_t evictionSize{0};
+};
+
+struct BackgroundPromotionStats {
+  // the number of items this worker evicted by looking at pools/classes stats
+  uint64_t nPromotedItems{0};
+
+  // number of times we went executed the thread //TODO: is this def correct?
+  uint64_t nTraversals{0};
+};
+
 struct Stats {
+  BackgroundEvictionStats backgndEvicStats;
+  BackgroundPromotionStats backgndPromoStats;
+
   uint64_t numEvictions{0};
   uint64_t numItems{0};
 
@@ -108,6 +134,9 @@ struct Stats {
   // cachebench.
   std::unordered_map<std::string, double> nvmCounters;
 
+  std::map<PoolId, std::map<ClassId, uint64_t>> backgroundEvictionClasses;
+  std::map<PoolId, std::map<ClassId, uint64_t>> backgroundPromotionClasses;
+
   // errors from the nvm engine.
   std::unordered_map<std::string, double> nvmErrors;
 
@@ -126,6 +155,14 @@ struct Stats {
                           pctFn(numEvictions, evictAttempts))
         << std::endl;
     out << folly::sformat("RAM Evictions : {:,}", numEvictions) << std::endl;
+
+    auto foreachAC = [&](auto& map, auto cb) {
+      for (auto& pidStat : map) {
+        for (auto& cidStat : pidStat.second) {
+          cb(pidStat.first, cidStat.first, cidStat.second);
+        }
+      }
+    };
 
     for (auto pid = 0U; pid < poolUsageFraction.size(); pid++) {
       out << folly::sformat("Fraction of pool {:,} used : {:.2f}", pid,
@@ -222,6 +259,42 @@ struct Stats {
         printLatencies("Cache Find API latency", cacheFindLatencyNs);
         printLatencies("Cache Allocate API latency", cacheAllocateLatencyNs);
       }
+    }
+
+    if (!backgroundEvictionClasses.empty() &&
+        backgndEvicStats.nEvictedItems > 0) {
+      out << "== Class Background Eviction Counters Map ==" << std::endl;
+      foreachAC(backgroundEvictionClasses,
+                [&](auto pid, auto cid, auto evicted) {
+                  out << folly::sformat("pid{:2} cid{:4} evicted: {:4}", pid,
+                                        cid, evicted)
+                      << std::endl;
+                });
+
+      out << folly::sformat("Background Evicted Items : {:,}",
+                            backgndEvicStats.nEvictedItems)
+          << std::endl;
+      out << folly::sformat("Background Evictor Traversals : {:,}",
+                            backgndEvicStats.nTraversals)
+          << std::endl;
+    }
+
+    if (!backgroundPromotionClasses.empty() &&
+        backgndPromoStats.nPromotedItems > 0) {
+      out << "== Class Background Promotion Counters Map ==" << std::endl;
+      foreachAC(backgroundPromotionClasses,
+                [&](auto pid, auto cid, auto promoted) {
+                  out << folly::sformat("pid{:2} cid{:4} promoted: {:4}", pid,
+                                        cid, promoted)
+                      << std::endl;
+                });
+
+      out << folly::sformat("Background Promoted Items : {:,}",
+                            backgndPromoStats.nPromotedItems)
+          << std::endl;
+      out << folly::sformat("Background Promoter Traversals : {:,}",
+                            backgndPromoStats.nTraversals)
+          << std::endl;
     }
 
     if (numNvmGets > 0 || numNvmDeletes > 0 || numNvmPuts > 0) {


### PR DESCRIPTION
Implements stubs for periodic workers for item eviction/promotion. The actual implementation of eviction and promotion is not part of this PR.

The idea behind introducing those workers is the following:
- BG eviction: to keep certain amount of free memory and decrease allocate latency
- BG promotion: to move hot items to memory and decrease read latency

Each BG worker can be customized with an eviction/promotion strategy (not part of this PR). One such strategy is implemented here: https://github.com/intel/CacheLib/blob/develop/cachelib/allocator/FreeThresholdStrategy.cpp

BG promotion is only helpful for multi-tier setup (unless we would have some way of predicting which NVM items are going to be accessed), but BG eviction can be useful for single-tier configuration as well to decrease allocate latency.