### PR TITLE
Shorten critical section in findEviction

### DIFF
--- a/cachelib/allocator/CacheAllocator-inl.h
+++ b/cachelib/allocator/CacheAllocator-inl.h
@@ -1461,7 +1461,7 @@ bool CacheAllocator<CacheTrait>::pushToNvmCacheFromRamForTesting(
 
   if (handle && nvmCache_ && shouldWriteToNvmCache(*handle) &&
       shouldWriteToNvmCacheExclusive(*handle)) {
-    nvmCache_->put(handle, nvmCache_->createPutToken(handle->getKey()));
+    nvmCache_->put(*handle, nvmCache_->createPutToken(handle->getKey()));
     return true;
   }
   return false;
@@ -2712,7 +2712,7 @@ CacheAllocator<CacheTrait>::advanceIteratorAndTryEvictRegularItem(
 
   if (evictToNvmCache && shouldWriteToNvmCacheExclusive(item)) {
     XDCHECK(token.isValid());
-    nvmCache_->put(evictHandle, std::move(token));
+    nvmCache_->put(*evictHandle, std::move(token));
   }
   return evictHandle;
 }
@@ -2774,7 +2774,7 @@ CacheAllocator<CacheTrait>::advanceIteratorAndTryEvictChainedItem(
   if (evictToNvmCache && shouldWriteToNvmCacheExclusive(*parentHandle)) {
     XDCHECK(token.isValid());
     XDCHECK(parentHandle->hasChainedItem());
-    nvmCache_->put(parentHandle, std::move(token));
+    nvmCache_->put(*parentHandle, std::move(token));
   }
 
   return parentHandle;
@@ -2812,7 +2812,7 @@ CacheAllocator<CacheTrait>::evictNormalItemForSlabRelease(Item& item) {
   // now that we are the only handle and we actually removed something from
   // the RAM cache, we enqueue it to nvmcache.
   if (evictToNvmCache && shouldWriteToNvmCacheExclusive(item)) {
-    nvmCache_->put(handle, std::move(token));
+    nvmCache_->put(*handle, std::move(token));
   }
 
   return handle;
@@ -2913,7 +2913,7 @@ CacheAllocator<CacheTrait>::evictChainedItemForSlabRelease(ChainedItem& child) {
   // the RAM cache, we enqueue it to nvmcache.
   if (evictToNvmCache && shouldWriteToNvmCacheExclusive(*parentHandle)) {
     DCHECK(parentHandle->hasChainedItem());
-    nvmCache_->put(parentHandle, std::move(token));
+    nvmCache_->put(*parentHandle, std::move(token));
   }
 
   return parentHandle;

--- a/cachelib/allocator/CacheAllocator.h
+++ b/cachelib/allocator/CacheAllocator.h
@@ -1652,6 +1652,12 @@ class CacheAllocator : public CacheBase {
                        bool removeFromNvm = true,
                        bool recordApiEvent = true);
 
+  // Must be called by the thread which called markForEviction and
+  // succeeded. After this call, the item is unlinked from Access and
+  // MM Containers. The item is no longer marked as exclusive and it's
+  // ref count is 0 - it's available for recycling.
+  void unlinkItemForEviction(Item& it);
+
   // Implementation to find a suitable eviction from the container. The
   // two parameters together identify a single container.
   //
@@ -1661,25 +1667,6 @@ class CacheAllocator : public CacheBase {
   Item* findEviction(PoolId pid, ClassId cid);
 
   using EvictionIterator = typename MMContainer::LockedIterator;
-
-  // Advance the current iterator and try to evict a regular item
-  //
-  // @param  mmContainer  the container to look for evictions.
-  // @param  itr          iterator holding the item
-  //
-  // @return  valid handle to regular item on success. This will be the last
-  //          handle to the item. On failure an empty handle.
-  WriteHandle advanceIteratorAndTryEvictRegularItem(MMContainer& mmContainer,
-                                                    EvictionIterator& itr);
-
-  // Advance the current iterator and try to evict a chained item
-  // Iterator may also be reset during the course of this function
-  //
-  // @param  itr          iterator holding the item
-  //
-  // @return  valid handle to the parent item on success. This will be the last
-  //          handle to the item
-  WriteHandle advanceIteratorAndTryEvictChainedItem(EvictionIterator& itr);
 
   // Deserializer CacheAllocatorMetadata and verify the version
   //

--- a/cachelib/allocator/nvmcache/NvmCache.h
+++ b/cachelib/allocator/nvmcache/NvmCache.h
@@ -158,11 +158,11 @@ class NvmCache {
   PutToken createPutToken(folly::StringPiece key);
 
   // store the given item in navy
-  // @param hdl         handle to cache item. should not be null
+  // @param item        reference to cache item
   // @param token       the put token for the item. this must have been
   //                    obtained before enqueueing the put to maintain
   //                    consistency
-  void put(WriteHandle& hdl, PutToken token);
+  void put(Item& item, PutToken token);
 
   // returns the current state of whether nvmcache is enabled or not. nvmcache
   // can be disabled if the backend implementation ends up in a corrupt state
@@ -286,7 +286,7 @@ class NvmCache {
   // returns true if there is tombstone entry for the key.
   bool hasTombStone(HashedKey hk);
 
-  std::unique_ptr<NvmItem> makeNvmItem(const WriteHandle& handle);
+  std::unique_ptr<NvmItem> makeNvmItem(const Item& item);
 
   // wrap an item into a blob for writing into navy.
   Blob makeBlob(const Item& it);

--- a/cachelib/allocator/nvmcache/tests/NvmCacheTests.cpp
+++ b/cachelib/allocator/nvmcache/tests/NvmCacheTests.cpp
@@ -2072,7 +2072,7 @@ TEST_F(NvmCacheTest, testEvictCB) {
     auto handle = cache.allocate(pid, key, 100);
     ASSERT_NE(nullptr, handle.get());
     std::memcpy(handle->getMemory(), val.data(), val.size());
-    auto buf = toIOBuf(makeNvmItem(handle));
+    auto buf = toIOBuf(makeNvmItem(*handle));
     evictCB(HashedKey{key.data()},
             navy::BufferView(buf.length(), buf.data()),
             navy::DestructorEvent::Recycled);
@@ -2093,7 +2093,7 @@ TEST_F(NvmCacheTest, testEvictCB) {
     ASSERT_NE(nullptr, handle.get());
     std::memcpy(handle->getMemory(), val.data(), val.size());
     cache.insertOrReplace(handle);
-    auto buf = toIOBuf(makeNvmItem(handle));
+    auto buf = toIOBuf(makeNvmItem(*handle));
     evictCB(HashedKey{key.data()},
             navy::BufferView(buf.length(), buf.data()),
             navy::DestructorEvent::Recycled);
@@ -2112,7 +2112,7 @@ TEST_F(NvmCacheTest, testEvictCB) {
     std::memcpy(handle->getMemory(), val.data(), val.size());
     cache.insertOrReplace(handle);
     handle->markNvmClean();
-    auto buf = toIOBuf(makeNvmItem(handle));
+    auto buf = toIOBuf(makeNvmItem(*handle));
     evictCB(HashedKey{key.data()},
             navy::BufferView(buf.length(), buf.data()),
             navy::DestructorEvent::Recycled);
@@ -2128,7 +2128,7 @@ TEST_F(NvmCacheTest, testEvictCB) {
     auto handle = cache.allocate(pid, key, 100);
     ASSERT_NE(nullptr, handle.get());
     std::memcpy(handle->getMemory(), val.data(), val.size());
-    auto buf = toIOBuf(makeNvmItem(handle));
+    auto buf = toIOBuf(makeNvmItem(*handle));
     evictCB(HashedKey{key.data()},
             navy::BufferView(buf.length(), buf.data()),
             navy::DestructorEvent::Removed);
@@ -2147,7 +2147,7 @@ TEST_F(NvmCacheTest, testEvictCB) {
     ASSERT_NE(nullptr, handle.get());
     std::memcpy(handle->getMemory(), val.data(), val.size());
     cache.insertOrReplace(handle);
-    auto buf = toIOBuf(makeNvmItem(handle));
+    auto buf = toIOBuf(makeNvmItem(*handle));
     evictCB(HashedKey{key.data()},
             navy::BufferView(buf.length(), buf.data()),
             navy::DestructorEvent::Removed);
@@ -2166,7 +2166,7 @@ TEST_F(NvmCacheTest, testEvictCB) {
     std::memcpy(handle->getMemory(), val.data(), val.size());
     cache.insertOrReplace(handle);
     handle->markNvmClean();
-    auto buf = toIOBuf(makeNvmItem(handle));
+    auto buf = toIOBuf(makeNvmItem(*handle));
     evictCB(HashedKey{key.data()},
             navy::BufferView(buf.length(), buf.data()),
             navy::DestructorEvent::Removed);
@@ -2228,7 +2228,7 @@ TEST_F(NvmCacheTest, testCreateItemAsIOBuf) {
     ASSERT_NE(nullptr, handle.get());
     std::memcpy(handle->getMemory(), val.data(), val.size());
 
-    auto dipper = makeNvmItem(handle);
+    auto dipper = makeNvmItem(*handle);
     auto iobuf = createItemAsIOBuf(key, *dipper);
 
     verifyItemInIOBuf(key, handle, iobuf.get());
@@ -2240,7 +2240,7 @@ TEST_F(NvmCacheTest, testCreateItemAsIOBuf) {
     ASSERT_NE(nullptr, handle.get());
     std::memcpy(handle->getMemory(), val.data(), val.size());
 
-    auto dipper = makeNvmItem(handle);
+    auto dipper = makeNvmItem(*handle);
     auto iobuf = createItemAsIOBuf(key, *dipper);
 
     verifyItemInIOBuf(key, handle, iobuf.get());
@@ -2269,7 +2269,7 @@ TEST_F(NvmCacheTest, testCreateItemAsIOBufChained) {
       cache.addChainedItem(handle, std::move(chainedIt));
     }
 
-    auto dipper = makeNvmItem(handle);
+    auto dipper = makeNvmItem(*handle);
     auto iobuf = createItemAsIOBuf(key, *dipper);
 
     verifyItemInIOBuf(key, handle, iobuf.get());

--- a/cachelib/allocator/nvmcache/tests/NvmTestBase.h
+++ b/cachelib/allocator/nvmcache/tests/NvmTestBase.h
@@ -108,7 +108,7 @@ class NvmCacheTest : public testing::Test {
   void pushToNvmCacheFromRamForTesting(WriteHandle& handle) {
     auto nvmCache = getNvmCache();
     if (nvmCache) {
-      nvmCache->put(handle, nvmCache->createPutToken(handle->getKey()));
+      nvmCache->put(*handle, nvmCache->createPutToken(handle->getKey()));
     }
   }
 
@@ -126,8 +126,8 @@ class NvmCacheTest : public testing::Test {
     return cache_ ? cache_->nvmCache_.get() : nullptr;
   }
 
-  std::unique_ptr<NvmItem> makeNvmItem(const WriteHandle& handle) {
-    return getNvmCache()->makeNvmItem(handle);
+  std::unique_ptr<NvmItem> makeNvmItem(const Item& item) {
+    return getNvmCache()->makeNvmItem(item);
   }
 
   std::unique_ptr<folly::IOBuf> createItemAsIOBuf(folly::StringPiece key,

--- a/cachelib/cachebench/runner/CacheStressor.h
+++ b/cachelib/cachebench/runner/CacheStressor.h
@@ -299,8 +299,11 @@ class CacheStressor : public Stressor {
         SCOPE_EXIT { throttleFn(); };
           // detect refcount leaks when run in  debug mode.
 #ifndef NDEBUG
-        auto checkCnt = [](int cnt) {
-          if (cnt != 0) {
+        auto checkCnt = [useCombinedLockForIterators =
+                             config_.useCombinedLockForIterators](int cnt) {
+          // if useCombinedLockForIterators is set handle count can be modified
+          // by a different thread
+          if (!useCombinedLockForIterators && cnt != 0) {
             throw std::runtime_error(folly::sformat("Refcount leak {}", cnt));
           }
         };

--- a/cachelib/cachebench/util/Config.cpp
+++ b/cachelib/cachebench/util/Config.cpp
@@ -67,6 +67,8 @@ StressorConfig::StressorConfig(const folly::dynamic& configJson) {
 
   JSONSetVal(configJson, checkNvmCacheWarmUp);
 
+  JSONSetVal(configJson, useCombinedLockForIterators);
+
   if (configJson.count("poolDistributions")) {
     for (auto& it : configJson["poolDistributions"]) {
       poolDistributions.push_back(DistributionConfig(it, configPath));
@@ -88,7 +90,7 @@ StressorConfig::StressorConfig(const folly::dynamic& configJson) {
   // If you added new fields to the configuration, update the JSONSetVal
   // to make them available for the json configs and increment the size
   // below
-  checkCorrectSize<StressorConfig, 496>();
+  checkCorrectSize<StressorConfig, 504>();
 }
 
 bool StressorConfig::usesChainedItems() const {

--- a/cachelib/cachebench/util/Config.h
+++ b/cachelib/cachebench/util/Config.h
@@ -267,6 +267,8 @@ struct StressorConfig : public JSONConfig {
   // By default, timestamps are in milliseconds.
   uint64_t timestampFactor{1000};
 
+  bool useCombinedLockForIterators{false};
+
   // admission policy for cache.
   std::shared_ptr<StressorAdmPolicy> admPolicy{};
 


### PR DESCRIPTION
This is the next part of the 'critical section' patch after https://github.com/facebook/CacheLib/pull/183. 

Original PR (some of the changes already upstreamed): https://github.com/facebook/CacheLib/pull/172

This PR contains changes to findEviction only. The remaining part (changes in SlabRelease code) will be provided in the next (final) PR.