### PR TITLE
Adds the support for Flexible Data Placement(FDP) over NVMe into the Cachelib.

### DIFF
--- a/cachelib/allocator/nvmcache/NavyConfig.h
+++ b/cachelib/allocator/nvmcache/NavyConfig.h
@@ -460,6 +460,9 @@ class NavyConfig {
 
   bool usesSimpleFile() const noexcept { return !fileName_.empty(); }
   bool usesRaidFiles() const noexcept { return raidPaths_.size() > 0; }
+  bool usesNvmeCharDevice() const { return (fileName_.find
+                (std::string("/dev/ng")) != std::string::npos); }
+  bool usesFDPDevice() const { return usesNvmeCharDevice(); }
   bool isBigHashEnabled() const {
     return enginesConfigs_[0].bigHash().getSizePct() > 0;
   }

--- a/cachelib/navy/CMakeLists.txt
+++ b/cachelib/navy/CMakeLists.txt
@@ -30,6 +30,8 @@ add_library (cachelib_navy
   block_cache/Region.cpp
   block_cache/RegionManager.cpp
   common/Buffer.cpp
+  common/NvmeInterface.cpp
+  common/IOInterface.cpp
   common/Device.cpp
   common/Hash.cpp
   common/SizeDistribution.cpp

--- a/cachelib/navy/Factory.h
+++ b/cachelib/navy/Factory.h
@@ -66,6 +66,9 @@ class BlockCacheProto {
   // read buffer. Must be multiple of block size.
   virtual void setReadBufferSize(uint32_t size) = 0;
 
+  // Set the placement Handle for capable devices (Ex: FDP)
+  virtual void setPlacementHandle(uint16_t placementHandle) = 0;
+
   // (Optional) How many clean regions GC should (try to) maintain in the pool.
   // Default: 1
   virtual void setCleanRegionsPool(uint32_t n) = 0;
@@ -102,6 +105,9 @@ class BigHashProto {
   // bit array of @hashTableBitSize bits.
   virtual void setBloomFilter(uint32_t numHashes,
                               uint32_t hashTableBitSize) = 0;
+
+  // Set the placement Handle for capable devices (Ex: FDP) for BigHash
+  virtual void setPlacementHandle(uint16_t placementHandle) = 0;
 };
 
 class EnginePairProto {
@@ -223,6 +229,21 @@ std::unique_ptr<Device> createFileDevice(
     bool truncateFile,
     uint32_t blockSize,
     std::shared_ptr<DeviceEncryptor> encryptor,
+    uint32_t maxDeviceWriteSize);
+
+// Creates a single NVMe Char device which supports FDP Mode.
+//
+// @param fileName              name of the file
+// @param singleFileSize        size of the file
+// @param blockSize             device block size
+// @param encryptor             encryption object
+// @param maxDeviceWriteSize    device maximum granularity of writes
+
+std::unique_ptr<Device> createNvmeFdpDevice(
+    std::string fileName,
+    uint64_t singleFileSize,
+    uint32_t blockSize,
+    std::shared_ptr<navy::DeviceEncryptor> encryptor,
     uint32_t maxDeviceWriteSize);
 
 } // namespace navy

--- a/cachelib/navy/bighash/BigHash.cpp
+++ b/cachelib/navy/bighash/BigHash.cpp
@@ -91,6 +91,7 @@ BigHash::BigHash(Config&& config, ValidConfigTag)
       bucketSize_{config.bucketSize},
       cacheBaseOffset_{config.cacheBaseOffset},
       numBuckets_{config.numBuckets()},
+      placementHandle_{config.placementHandle},
       bloomFilter_{std::move(config.bloomFilter)},
       device_{*config.device} {
   XLOGF(INFO,
@@ -535,7 +536,8 @@ Buffer BigHash::readBucket(BucketId bid) {
 bool BigHash::writeBucket(BucketId bid, Buffer buffer) {
   auto* bucket = reinterpret_cast<Bucket*>(buffer.data());
   bucket->setChecksum(Bucket::computeChecksum(buffer.view()));
-  return device_.write(getBucketOffset(bid), std::move(buffer));
+  return device_.write(placementHandle_, getBucketOffset(bid),
+              std::move(buffer));
 }
 } // namespace navy
 } // namespace cachelib

--- a/cachelib/navy/bighash/BigHash.h
+++ b/cachelib/navy/bighash/BigHash.h
@@ -62,6 +62,8 @@ class BigHash final : public Engine {
     uint64_t cacheBaseOffset{};
     uint64_t cacheSize{};
     Device* device{nullptr};
+    // placement info if device placement(FDP) is enabled
+    uint16_t placementHandle{};
 
     ExpiredCheck checkExpired;
     DestructorCallback destructorCb;
@@ -203,6 +205,7 @@ class BigHash final : public Engine {
   Device& device_;
   std::unique_ptr<folly::SharedMutex[]> mutex_{
       new folly::SharedMutex[kNumMutexes]};
+  const uint16_t placementHandle_{};
 
   // thread local counters in synchronized path
   mutable TLCounter lookupCount_;

--- a/cachelib/navy/block_cache/BlockCache.cpp
+++ b/cachelib/navy/block_cache/BlockCache.cpp
@@ -138,6 +138,7 @@ BlockCache::BlockCache(Config&& config, ValidConfigTag)
                      std::move(config.evictionPolicy),
                      config.numInMemBuffers,
                      config.numPriorities,
+                     config.placementHandle,
                      config.inMemBufFlushRetryLimit},
       allocator_{regionManager_, config.numPriorities},
       reinsertionPolicy_{makeReinsertionPolicy(config.reinsertionConfig)} {

--- a/cachelib/navy/block_cache/BlockCache.h
+++ b/cachelib/navy/block_cache/BlockCache.h
@@ -62,6 +62,8 @@ class BlockCache final : public Engine {
     uint64_t regionSize{16 * 1024 * 1024};
     // See AbstractCacheProto::setReadBufferSize
     uint32_t readBufferSize{};
+    // data placement handle used if device is capable (Ex: FDP)
+    uint16_t placementHandle{};
     // Job scheduler for background tasks
     JobScheduler* scheduler{};
     // Clean region pool size

--- a/cachelib/navy/block_cache/RegionManager.cpp
+++ b/cachelib/navy/block_cache/RegionManager.cpp
@@ -33,8 +33,10 @@ RegionManager::RegionManager(uint32_t numRegions,
                              std::unique_ptr<EvictionPolicy> policy,
                              uint32_t numInMemBuffers,
                              uint16_t numPriorities,
+                             uint16_t placementHandle,
                              uint16_t inMemBufFlushRetryLimit)
     : numPriorities_{numPriorities},
+      placementHandle_{placementHandle},
       inMemBufFlushRetryLimit_{inMemBufFlushRetryLimit},
       numRegions_{numRegions},
       regionSize_{regionSize},
@@ -490,7 +492,7 @@ bool RegionManager::deviceWrite(RelAddress addr, BufferView view) {
   const auto bufSize = view.size();
   XDCHECK(isValidIORange(addr.offset(), bufSize));
   auto physOffset = physicalOffset(addr);
-  if (!device_.write(physOffset, view)) {
+  if (!device_.write(placementHandle_, physOffset, view)) {
     return false;
   }
   physicalWrittenCount_.add(bufSize);

--- a/cachelib/navy/block_cache/RegionManager.h
+++ b/cachelib/navy/block_cache/RegionManager.h
@@ -73,6 +73,8 @@ class RegionManager {
   // @param numInMemBuffers           number of in memory buffers
   // @param numPriorities             max number of priorities allowed for
   //                                  regions
+  // @param placementHandle           data placement handle ID used for any
+  //                                  placement enabled devices
   // @param inMemBufFlushRetryLimit   max number of flushing retry times for
   //                                  in-mem buffer
   RegionManager(uint32_t numRegions,
@@ -86,6 +88,7 @@ class RegionManager {
                 std::unique_ptr<EvictionPolicy> policy,
                 uint32_t numInMemBuffers,
                 uint16_t numPriorities,
+                uint16_t placementHandle,
                 uint16_t inMemBufFlushRetryLimit);
   RegionManager(const RegionManager&) = delete;
   RegionManager& operator=(const RegionManager&) = delete;
@@ -286,6 +289,8 @@ class RegionManager {
   const uint32_t numCleanRegions_{};
 
   std::atomic<uint64_t> seqNumber_{0};
+
+  const uint16_t placementHandle_{};
 
   uint32_t reclaimsScheduled_{0};
   JobScheduler& scheduler_;

--- a/cachelib/navy/common/IOInterface.cpp
+++ b/cachelib/navy/common/IOInterface.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/File.h>
+#include <folly/Format.h>
+
+#include <linux/nvme_ioctl.h>
+#include <sys/ioctl.h>
+#include <errno.h>
+
+#include <cstring>
+#include <numeric>
+#include "cachelib/navy/common/IOInterface.h"
+#include "cachelib/navy/common/NvmeInterface.h"
+
+namespace facebook {
+namespace cachelib {
+namespace navy {
+
+void prepNvmeUringCmd(struct nvme_uring_cmd *cmd, const IOData ioData,
+    const NvmeData nvmeData, InterfaceDDir dir) {
+  memset(cmd, 0, sizeof(struct nvme_uring_cmd));
+  if (dir == DDIR_READ)
+    cmd->opcode = nvme_cmd_read;
+  else
+    cmd->opcode = nvme_cmd_write;
+
+  uint64_t sLba = ioData.offset() >> nvmeData.lbaShift();
+  uint32_t nLb  = (ioData.size() >> nvmeData.lbaShift()) - 1;
+
+  /* cdw10 and cdw11 represent starting lba */
+  cmd->cdw10 = sLba & 0xffffffff;
+  cmd->cdw11 = sLba >> 32;
+  /* cdw12 represent number of lba's for read/write */
+  cmd->cdw12 = (ioData.dtype() & 0xFF) << 20 | nLb;
+  cmd->cdw13 = (ioData.dspec() << 16);
+  cmd->addr = (uint64_t)ioData.buf();
+  cmd->data_len = ioData.size();
+
+  cmd->nsid = nvmeData.nsId();
+}
+
+bool submitNvmeUringCmd(struct io_uring *ring, const IOData ioData,
+    const NvmeData nvmeData, InterfaceDDir dir) {
+  struct io_uring_sqe *sqe;
+  struct io_uring_cqe *cqe;
+  struct nvme_uring_cmd *cmd;
+  const __u64 token = 0xDEADBEEF;
+  int32_t status = -1;
+
+  sqe = io_uring_get_sqe(ring);
+  if(sqe == nullptr) {
+    throw std::invalid_argument("Uring SQE is NULL!");
+  }
+  sqe->fd = ioData.fd();
+  sqe->user_data = token;
+  sqe->opcode = IORING_OP_URING_CMD ;
+  sqe->cmd_op = NVME_URING_CMD_IO ;
+  cmd = (struct nvme_uring_cmd *)&sqe->cmd;
+  if(cmd == nullptr) {
+    throw std::invalid_argument("Uring cmd is NULL!");
+  }
+
+  prepNvmeUringCmd(cmd, ioData, nvmeData, dir);
+
+  io_uring_submit(ring);
+  io_uring_wait_cqe(ring, &cqe);
+  if(cqe == nullptr) {
+    throw std::invalid_argument("Uring CQE is NULL!");
+  }
+
+  switch (cqe->user_data) {
+    case token:
+    {
+      status = cqe->res;
+      int64_t result1 = cqe->big_cqe[0];
+      int64_t result2 = cqe->big_cqe[1];
+      if(status != 0) {
+        XLOGF(INFO, "Completion Err for IO:status: {} res1: {} res2: {}\n",
+          status, result1, result2);
+      }
+      io_uring_cqe_seen(ring, cqe);
+    }
+    break;
+    default:
+      XLOGF(INFO, "invalid user data {}\n", cqe->user_data);
+  }
+
+  return (status == 0);
+}
+
+// This makes sure that every thread initializes it's own copy of uring
+thread_local bool needInit_{true};
+thread_local struct io_uring uring_;
+
+class IOUringPassthruInterface final : public IOInterface {
+public:
+  IOUringPassthruInterface() {}
+  IOUringPassthruInterface(const IOUringPassthruInterface&) = delete;
+  IOUringPassthruInterface& operator=(const IOUringPassthruInterface&) = delete;
+
+  ~IOUringPassthruInterface() {}
+
+private:
+  bool nvmeIOImpl(const IOData ioData, const NvmeData nvmeData,
+                          InterfaceDDir dir) {
+    if(needInit_) {
+      nvmeUringInit();
+      needInit_ = false;
+    }
+    return submitNvmeUringCmd(&uring_, ioData, nvmeData, dir);
+  }
+
+  bool nvmeUringInit() {
+    struct io_uring_params p = {};
+    const unsigned int qdepth = 128;
+
+    p.flags = IORING_SETUP_SQE128 | IORING_SETUP_CQE32;
+    int ret = io_uring_queue_init(qdepth, &uring_, p.flags);
+    if(ret != 0) {
+      throw std::invalid_argument("URING init error!");
+    }
+
+    return (ret == 0);
+  }
+
+  void nvmeUringExit() {
+    io_uring_queue_exit(&uring_);
+  }
+};
+
+bool IOInterface::nvmeIO(const IOData ioData, const NvmeData nvmeData, InterfaceDDir dir) {
+  return nvmeIOImpl(ioData, nvmeData, dir);
+}
+
+std::unique_ptr<IOInterface> createIOUringNvmeInterface() {
+  return std::make_unique<IOUringPassthruInterface>();
+}
+} // namespace navy
+} // namespace cachelib
+} // namespace facebook

--- a/cachelib/navy/common/IOInterface.h
+++ b/cachelib/navy/common/IOInterface.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <liburing.h>
+#include "cachelib/navy/common/Types.h"
+#include "cachelib/navy/common/Utils.h"
+
+namespace facebook {
+namespace cachelib {
+namespace navy {
+
+class NvmeData;
+
+enum InterfaceDDir {
+  DDIR_READ = 0,
+  DDIR_WRITE = 1,
+};
+
+class IOData {
+ public:
+  IOData() = default;
+  IOData& operator=(const IOData&) = default;
+
+  explicit IOData(int fd, uint64_t offset, uint32_t size, uint8_t *buf)
+    : fd_{fd}, offset_{offset}, size_{size}, buf_{buf} {}
+
+  int fd() const { return fd_;}
+  uint64_t offset() const { return offset_;}
+  uint32_t size() const { return size_;}
+  uint8_t* buf() const { return buf_;}
+  uint8_t dtype() const { return dType_;}
+  uint16_t dspec() const { return dSpec_;}
+
+  void setDirectiveData(uint8_t dType, uint16_t dSpec) {
+    dType_ = dType;
+    dSpec_ = dSpec;
+  }
+
+ private:
+  int fd_;
+  uint64_t offset_{0};
+  uint32_t size_{0};
+  uint8_t *buf_{};
+  uint8_t dType_{0};
+  uint16_t dSpec_{0};
+};
+
+// IOInterface is an abstraction layer for IO interface access
+class IOInterface {
+ public:
+  explicit IOInterface() {}
+  bool nvmeIO(const IOData ioData, const NvmeData nvmeData, InterfaceDDir dir);
+
+ protected:
+  virtual bool nvmeIOImpl(const IOData ioData, const NvmeData nvmeData,
+                              InterfaceDDir dir) = 0;
+};
+
+std::unique_ptr<IOInterface> createIOUringNvmeInterface();
+} // namespace navy
+} // namespace cachelib
+} // namespace facebook

--- a/cachelib/navy/common/NvmeInterface.cpp
+++ b/cachelib/navy/common/NvmeInterface.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <linux/nvme_ioctl.h>
+#include <sys/ioctl.h>
+#include <errno.h>
+#include <cstring>
+#include <numeric>
+#include "cachelib/navy/common/NvmeInterface.h"
+
+namespace facebook {
+namespace cachelib {
+namespace navy {
+
+NvmeInterface::NvmeInterface(int fd) {
+  // Many NVMe controllers has the tfr size limit. Now use a default value.
+  static constexpr uint32_t kMaxTfrSize = 262144u;
+
+  XLOG(INFO)<< "Creating NvmeInterface, fd :" << fd;
+  interface_ = createIOUringNvmeInterface();
+  nvmeData_ = readNvmeInfo(fd);
+  maxTfrSize_ = kMaxTfrSize;
+}
+
+IOData NvmeInterface::prepIO(int fd, uint64_t offset, uint32_t size,
+                          const void* buf) {
+  const uint8_t* bufp = reinterpret_cast<const uint8_t*>(buf);
+  IOData ioData{fd, offset, size, const_cast<uint8_t*>(bufp)};
+  return ioData;
+}
+
+bool NvmeInterface::doIO(int fd, uint64_t offset, uint32_t size,
+                          const void* buf, InterfaceDDir dir) {
+  uint32_t remainingSize = size;
+  uint8_t* bufp = (uint8_t*)buf;
+  bool ret;
+
+  while (remainingSize) {
+    auto ioSize = std::min<size_t>(maxTfrSize_, remainingSize);
+    IOData ioData = prepIO(fd, offset, ioSize, bufp);
+
+    ret = interface_->nvmeIO(ioData, nvmeData_, dir);
+    if(ret == false) {
+      break;
+    }
+    offset += ioSize;
+    bufp += ioSize;
+    remainingSize -= ioSize;
+  }
+  return ret;
+}
+
+bool NvmeInterface::writeNvme(int fd, uint64_t offset, uint32_t size,
+                          const void* buf) {
+  return doIO(fd, offset, size, buf, DDIR_WRITE);
+}
+
+bool NvmeInterface::readNvme(int fd, uint64_t offset, uint32_t size,
+                          void* buf) {
+  return doIO(fd, offset, size, buf, DDIR_READ);
+}
+
+bool NvmeInterface::writeNvmeDirective(int fd, uint64_t offset, uint32_t size,
+              const void* buf, uint16_t placementID) {
+  // Dtype of 2 prompts the device to use data placement mode
+  // And placementID is used as RG_RUH combination
+  static constexpr uint8_t kPlacementMode = 2;
+  uint32_t remainingSize = size;
+  uint8_t* bufp = (uint8_t*)buf;
+  bool ret;
+
+  while (remainingSize) {
+    auto ioSize = std::min<size_t>(maxTfrSize_, remainingSize);
+    IOData ioData = prepIO(fd, offset, ioSize, bufp);
+    ioData.setDirectiveData(kPlacementMode, placementID);
+
+    ret = interface_->nvmeIO(ioData, nvmeData_, DDIR_WRITE);
+    if(ret == false) {
+      break;
+    }
+    offset += ioSize;
+    bufp += ioSize;
+    remainingSize -= ioSize;
+  }
+  return ret;
+}
+
+NvmeData NvmeInterface::readNvmeInfo(int fd) {
+  int namespace_id = ioctl(fd, NVME_IOCTL_ID);
+  if (namespace_id < 0) {
+    XLOG(ERR)<< "failed to fetch namespace-id, fd "<< fd;
+    return NvmeData{};
+  }
+
+  struct nvme_id_ns ns;
+  struct nvme_passthru_cmd cmd = {
+    .opcode         = nvme_admin_identify,
+    .nsid           = (uint32_t)namespace_id,
+    .addr           = (uint64_t)(uintptr_t)&ns,
+    .data_len       = NVME_IDENTIFY_DATA_SIZE,
+    .cdw10          = NVME_IDENTIFY_CNS_NS,
+    .cdw11          = NVME_CSI_NVM << NVME_IDENTIFY_CSI_SHIFT,
+    .timeout_ms     = NVME_DEFAULT_IOCTL_TIMEOUT,
+  };
+
+  int err = ioctl(fd, NVME_IOCTL_ADMIN_CMD, &cmd);
+  if(err) {
+    XLOG(ERR)<< "failed to fetch identify namespace";
+    return NvmeData{};
+  }
+
+  auto lbaShift = (uint32_t)ilog2(1 << ns.lbaf[(ns.flbas & 0x0f)].ds);
+  XLOG(INFO) <<"Nvme Device Info :" <<namespace_id<<"lbashift: "
+                      <<lbaShift<<"size: "<<ns.nsze;
+
+  return NvmeData{namespace_id, lbaShift, ns.nsze};
+}
+} // namespace navy
+} // namespace cachelib
+} // namespace facebook

--- a/cachelib/navy/common/NvmeInterface.h
+++ b/cachelib/navy/common/NvmeInterface.h
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "cachelib/navy/common/IOInterface.h"
+#include "cachelib/navy/common/Device.h"
+#include <liburing.h>
+
+namespace facebook {
+namespace cachelib {
+namespace navy {
+// Reference: https://github.com/axboe/fio/blob/master/engines/nvme.h
+// If the uapi headers installed on the system lacks nvme uring command
+// support, use the local version to prevent compilation issues.
+#ifndef CONFIG_NVME_URING_CMD
+struct nvme_uring_cmd {
+  __u8  opcode;
+  __u8  flags;
+  __u16 rsvd1;
+  __u32 nsid;
+  __u32 cdw2;
+  __u32 cdw3;
+  __u64 metadata;
+  __u64 addr;
+  __u32 metadata_len;
+  __u32 data_len;
+  __u32 cdw10;
+  __u32 cdw11;
+  __u32 cdw12;
+  __u32 cdw13;
+  __u32 cdw14;
+  __u32 cdw15;
+  __u32 timeout_ms;
+  __u32 rsvd2;
+};
+
+#define NVME_URING_CMD_IO _IOWR('N', 0x80, struct nvme_uring_cmd)
+#define NVME_URING_CMD_IO_VEC _IOWR('N', 0x81, struct nvme_uring_cmd)
+#endif /* CONFIG_NVME_URING_CMD */
+
+#define NVME_DEFAULT_IOCTL_TIMEOUT 0
+#define NVME_IDENTIFY_DATA_SIZE 4096
+#define NVME_IDENTIFY_CSI_SHIFT 24
+enum nvme_identify_cns {
+  NVME_IDENTIFY_CNS_NS    = 0x00,
+  NVME_IDENTIFY_CNS_CSI_NS  = 0x05,
+  NVME_IDENTIFY_CNS_CSI_CTRL  = 0x06,
+};
+
+enum nvme_csi {
+  NVME_CSI_NVM      = 0,
+  NVME_CSI_KV     = 1,
+  NVME_CSI_ZNS      = 2,
+};
+
+enum nvme_admin_opcode {
+  nvme_admin_get_log_page         = 0x02,
+  nvme_admin_identify             = 0x06,
+  nvme_admin_get_features         = 0x0a,
+};
+
+enum nvme_io_opcode {
+  nvme_cmd_write      = 0x01,
+  nvme_cmd_read     = 0x02,
+  nvme_cmd_dsm      = 0x09,
+  nvme_cmd_io_mgmt_recv   = 0x12,
+  nvme_cmd_io_mgmt_send   = 0x1d,
+  nvme_zns_cmd_mgmt_send    = 0x79,
+  nvme_zns_cmd_mgmt_recv    = 0x7a,
+};
+
+struct nvme_lbaf {
+  __le16 ms;
+  __u8   ds;
+  __u8   rp;
+};
+
+struct nvme_id_ns {
+  __le64 nsze;
+  __le64 ncap;
+  __le64 nuse;
+  __u8   nsfeat;
+  __u8   nlbaf;
+  __u8   flbas;
+  __u8   mc;
+  __u8   dpc;
+  __u8   dps;
+  __u8   nmic;
+  __u8   rescap;
+  __u8   fpi;
+  __u8   dlfeat;
+  __le16 nawun;
+  __le16 nawupf;
+  __le16 nacwu;
+  __le16 nabsn;
+  __le16 nabo;
+  __le16 nabspf;
+  __le16 noiob;
+  __u8   nvmcap[16];
+  __le16 npwg;
+  __le16 npwa;
+  __le16 npdg;
+  __le16 npda;
+  __le16 nows;
+  __le16 mssrl;
+  __le32 mcl;
+  __u8   msrc;
+  __u8   rsvd81[11];
+  __le32 anagrpid;
+  __u8   rsvd96[3];
+  __u8   nsattr;
+  __le16 nvmsetid;
+  __le16 endgid;
+  __u8   nguid[16];
+  __u8   eui64[8];
+  struct nvme_lbaf  lbaf[16];
+  __u8   rsvd192[192];
+  __u8   vs[3712];
+};
+
+static inline int ilog2(uint32_t i) {
+  int log = -1;
+
+  while (i) {
+    i >>= 1;
+    log++;
+  }
+  return log;
+}
+
+class NvmeData {
+ public:
+  NvmeData() = default;
+  NvmeData& operator=(const NvmeData&) = default;
+
+  explicit NvmeData(int nsId, uint32_t lbaShift, uint64_t nLba)
+    : nsId_{nsId}, lbaShift_{lbaShift}, nLba_{nLba} {}
+
+  int nsId() const { return nsId_;}
+  uint32_t lbaShift() const { return lbaShift_;}
+  uint64_t nLba() const { return nLba_;}
+
+ private:
+  int nsId_;
+  uint32_t lbaShift_;
+  uint64_t nLba_;
+};
+
+class NvmeInterface {
+ public:
+  NvmeInterface(int fd);
+  NvmeInterface(const NvmeInterface&) = delete;
+  bool writeNvme(int fd, uint64_t offset, uint32_t size, const void* buf);
+  bool readNvme(int fd, uint64_t offset, uint32_t size, void* buf);
+  bool writeNvmeDirective(int fd, uint64_t offset, uint32_t size,
+      const void* buf, uint16_t placementID);
+
+ private:
+  IOData prepIO(int fd, uint64_t offset, uint32_t size,
+                                    const void* buf);
+  bool doIO(int fd, uint64_t offset, uint32_t size,
+                            const void* buf, InterfaceDDir dir);
+  NvmeData readNvmeInfo(int fd);
+
+  std::unique_ptr<IOInterface> interface_{};
+  NvmeData nvmeData_{};
+  uint32_t maxTfrSize_{};
+};
+} // namespace navy
+} // namespace cachelib
+} // namespace facebook

--- a/cachelib/navy/common/NvmeInterface.h
+++ b/cachelib/navy/common/NvmeInterface.h
@@ -58,9 +58,10 @@ struct nvme_uring_cmd {
 #define NVME_IDENTIFY_CSI_SHIFT 24
 
 enum nvme_identify_cns {
-  NVME_IDENTIFY_CNS_NS    = 0x00,
-  NVME_IDENTIFY_CNS_CSI_NS  = 0x05,
-  NVME_IDENTIFY_CNS_CSI_CTRL  = 0x06,
+  NVME_IDENTIFY_CNS_NS          = 0x00,
+  NVME_IDENTIFY_CNS_CTRL        = 0x01,
+  NVME_IDENTIFY_CNS_CSI_NS      = 0x05,
+  NVME_IDENTIFY_CNS_CSI_CTRL    = 0x06,
 };
 
 enum nvme_csi {
@@ -175,17 +176,20 @@ class NvmeData {
   NvmeData() = default;
   NvmeData& operator=(const NvmeData&) = default;
 
-  explicit NvmeData(int nsId, uint32_t lbaShift, uint64_t nLba)
-    : nsId_{nsId}, lbaShift_{lbaShift}, nLba_{nLba} {}
+  explicit NvmeData(int nsId, uint32_t lbaShift, uint64_t nLba,
+      uint32_t maxTransferSize) : nsId_{nsId}, lbaShift_{lbaShift}, nLba_{nLba},
+                                 maxTransferSize_{maxTransferSize} {}
 
   int nsId() const { return nsId_;}
   uint32_t lbaShift() const { return lbaShift_;}
   uint64_t nLba() const { return nLba_;}
+  uint32_t maxTransferSize() const { return maxTransferSize_;}
 
  private:
   int nsId_;
   uint32_t lbaShift_;
   uint64_t nLba_;
+  uint32_t maxTransferSize_;
 };
 
 class NvmeInterface {
@@ -209,7 +213,6 @@ class NvmeInterface {
 
   std::unique_ptr<IOInterface> interface_{};
   NvmeData nvmeData_{};
-  uint32_t maxTfrSize_{};
 };
 } // namespace navy
 } // namespace cachelib

--- a/cachelib/navy/serialization/RecordIO.cpp
+++ b/cachelib/navy/serialization/RecordIO.cpp
@@ -80,7 +80,7 @@ class DeviceMetaDataWriter final : public RecordWriter {
         Buffer buffer = dev_.makeIOBuffer(blockSize_);
         memcpy(buffer.data(), bufferData, bufIndex_);
         memset(buffer.data() + bufIndex_, 0, blockSize_ - bufIndex_);
-        dev_.write(offset_, std::move(buffer));
+        dev_.write(0, offset_, std::move(buffer));
         offset_ += blockSize_;
       }
     }
@@ -89,7 +89,7 @@ class DeviceMetaDataWriter final : public RecordWriter {
       // of metadata clear
       Buffer buffer = dev_.makeIOBuffer(blockSize_);
       memset(buffer.data(), 0, blockSize_);
-      dev_.write(offset_, std::move(buffer));
+      dev_.write(0, offset_, std::move(buffer));
     }
   }
 
@@ -113,7 +113,7 @@ class DeviceMetaDataWriter final : public RecordWriter {
       Buffer buffer = dev_.makeIOBuffer(blockSize_);
       memcpy(buffer.data(), bufferData, blockSize_);
 
-      if (!dev_.write(offset_, std::move(buffer))) {
+      if (!dev_.write(0, offset_, std::move(buffer))) {
         throw std::invalid_argument(
             folly::sformat("write failed: offset = {}", offset_));
       }
@@ -150,7 +150,7 @@ class DeviceMetaDataWriter final : public RecordWriter {
   bool invalidate() override {
     Buffer invalidateBuffer{blockSize_, blockSize_};
     memset(invalidateBuffer.data(), 0, blockSize_);
-    return dev_.write(0, std::move(invalidateBuffer));
+    return dev_.write(0, 0, std::move(invalidateBuffer));
   }
 
  private:


### PR DESCRIPTION
Adds the support for Flexible Data Placement(FDP) over NVMe into the Cachelib.

This PR adds the changes for BlockCache and BigHash to segregate their data streams in physical NAND media
through the FDP placement Identifiers. With this changes, the Cachelib can reduce the Device Write
Amplification (WAF) in high SSD utilization scenarios such as above 50% of the SSD capacity ("nvmCacheSizeMB").

It introduces a 'placementHandle' concept, which can be used by both BC and BH of Navy on device write() calls.
The 'placementHandle' have to be allocated from the device. The placement capable devices will return a valid
handle, while the non-capable devices will return a default handle. 'placementhandle' is envisioned as an
abstract concept for all data placement technologies; not just for FDP.

This introduces a new class NvmeFDPDevice in Device layer, since FDP io semantics need to be handled differently from the 
regular block interface. At the moment, NVMe FDP directives can be passed to the kernel only through nvme-passthrough
interface. So this changes introduces two new classes - NvmeInterface and IOInterface.
NvmeInteface is an abstraction for all Nvme specific details, many of which can be eventually moved to some library.
And IOInterface is an abstraction around the IO interfaces supported - IOUring Passthrough is used in this version.

The user needs to configure an NVMe char device instead of the regular block device to enable the FDP mode.
(Ex:"nvmCachePaths": ["/dev/ng0n1"])

It does not incorporate FDP Reclaim Unit(RU) boundary awareness during allocation and de-allocation of blocks.
That feature can be incorporated later if required.

A few good to have features which are omitted for now.
 - Abstracting 'placementHandle' using a class instead of 'uint16_t' to handle different Data placement technologies.
 - Support for async io function in iouring path. 
   This useful when BC write/read of 16MB is broken down into 256KB chunks. With async calls, these chunks can be done in parallel.