### PR TITLE
modified for building Cachebench on CentOS9

### DIFF
--- a/contrib/build.sh
+++ b/contrib/build.sh
@@ -65,7 +65,7 @@ build_centos_8()
 
 build_centos_9()
 {
-  ./public_tld/contrib/prerequisites-centos9.sh \
+  ./contrib/prerequisites-centos9.sh \
     || die "failed to install packages for CentOS"
 }
 


### PR DESCRIPTION
When building in CentOS9 had found the path missing (found there was an additional path compared to other build function)