### PR TITLE
Add the support for Zoned Namespace SSD (ZNS) over NVMe into CacheLib.

### DIFF
--- a/cachelib/CMakeLists.txt
+++ b/cachelib/CMakeLists.txt
@@ -105,7 +105,10 @@ find_package(wangle CONFIG REQUIRED)
 find_package(Zlib REQUIRED)
 find_package(Zstd REQUIRED)
 find_package(FBThrift REQUIRED) # must come after wangle
-
+find_package(Zbd REQUIRED)
+find_package(PkgConfig REQUIRED)
+PKG_SEARCH_MODULE(PKG_ZBD REQUIRED libzbd)
+MESSAGE(STATUS "PKG_ZBD_LIBRARY_DIRS ${PKG_ZBD_LIBRARY_DIRS}")
 find_package(uring)
 if (NOT uring_FOUND)
   add_definitions(-DCACHELIB_IOURING_DISABLE)
@@ -133,7 +136,7 @@ function (GENERIC_ADD_TEST TEST_PREFIX SOURCE_FILE)
 
   add_executable("${TEST_PREFIX}-${TEST_NAME}" "${SOURCE_FILE}")
   target_link_libraries("${TEST_PREFIX}-${TEST_NAME}" "${ARGN}")
-
+  target_link_libraries("${TEST_PREFIX}-${TEST_NAME}"  -lzbd)
   install(
     TARGETS "${TEST_PREFIX}-${TEST_NAME}"
     DESTINATION ${TESTS_INSTALL_DIR}

--- a/cachelib/allocator/CMakeLists.txt
+++ b/cachelib/allocator/CMakeLists.txt
@@ -92,6 +92,7 @@ if (BUILD_TESTS)
     GTest::gtest
     GTest::gtest_main
     GTest::gmock
+    ${ZBD_LIBRARIES}
   )
 
 

--- a/cachelib/allocator/nvmcache/NavyConfig.h
+++ b/cachelib/allocator/nvmcache/NavyConfig.h
@@ -482,6 +482,7 @@ class NavyConfig {
 
   bool usesSimpleFile() const noexcept { return !fileName_.empty(); }
   bool usesRaidFiles() const noexcept { return raidPaths_.size() > 0; }
+  bool usesZoneFile() const noexcept { return useZoneFile_; }
   bool isBigHashEnabled() const {
     return enginesConfigs_[0].bigHash().getSizePct() > 0;
   }
@@ -621,7 +622,9 @@ class NavyConfig {
   }
 
   EnginesSelector getEnginesSelector() const { return selector_; }
-
+  void setUseZoneFile(bool useZoneFile) noexcept {
+    useZoneFile_ = useZoneFile;
+  }
  private:
   // ============ AP settings =============
   // Name of the admission policy.
@@ -685,6 +688,7 @@ class NavyConfig {
   // Whether to use write size (instead of parcel size) for Navy admission
   // policy.
   bool useEstimatedWriteSize_{false};
+   bool useZoneFile_{false};
 };
 } // namespace navy
 } // namespace cachelib

--- a/cachelib/benchmarks/CMakeLists.txt
+++ b/cachelib/benchmarks/CMakeLists.txt
@@ -26,6 +26,7 @@ if (BUILD_TESTS)
     Folly::follybenchmark
     glog::glog
     gflags
+    ${ZBD_LIBRARIES} 
     GTest::gtest
     GTest::gmock
   )

--- a/cachelib/cachebench/CMakeLists.txt
+++ b/cachelib/cachebench/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(cachelib_cachebench PUBLIC
   cachelib_datatype
   cachelib_allocator
   gflags
+  ${ZBD_LIBRARIES}
 )
 
 if ((CMAKE_SYSTEM_NAME STREQUAL Linux) AND
@@ -74,6 +75,7 @@ if (BUILD_TESTS)
     GTest::gtest
     GTest::gtest_main
     GTest::gmock
+    ${ZBD_LIBRARIES} 
   )
 
 

--- a/cachelib/cachebench/cache/Cache-inl.h
+++ b/cachelib/cachebench/cache/Cache-inl.h
@@ -173,7 +173,8 @@ Cache<Allocator>::Cache(const CacheConfig& config,
           config_.navyReqOrderShardsPower);
     }
     nvmConfig.navyConfig.setBlockSize(config_.navyBlockSize);
-
+    nvmConfig.navyConfig.setUseZoneFile(config_.isZoneFile);
+    printf(" config_.isZoneFile [%d]\n", config_.isZoneFile);
     // configure BlockCache
     auto& bcConfig = nvmConfig.navyConfig.blockCache()
                          .setDataChecksum(config_.navyDataChecksum)

--- a/cachelib/cachebench/util/CacheConfig.cpp
+++ b/cachelib/cachebench/util/CacheConfig.cpp
@@ -104,6 +104,7 @@ CacheConfig::CacheConfig(const folly::dynamic& configJson) {
   JSONSetVal(configJson, tickerSynchingSeconds);
   JSONSetVal(configJson, enableItemDestructorCheck);
   JSONSetVal(configJson, enableItemDestructor);
+  JSONSetVal(configJson, isZoneFile);
   JSONSetVal(configJson, nvmAdmissionRetentionTimeThreshold);
 
   JSONSetVal(configJson, customConfigJson);

--- a/cachelib/cachebench/util/CacheConfig.h
+++ b/cachelib/cachebench/util/CacheConfig.h
@@ -260,6 +260,7 @@ struct CacheConfig : public JSONConfig {
   // enable the ItemDestructor feature, but not check correctness,
   // this verifies whether the feature affects throughputs.
   bool enableItemDestructor{false};
+  bool isZoneFile{false};
 
   // If specified, we will not admit any item into NvmCache if their
   // eviction-age is more than this threshold. 0 means no threshold

--- a/cachelib/cmake/FindZbd.cmake
+++ b/cachelib/cmake/FindZbd.cmake
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# - Try to find Glog
+# Once done, this will define
+#
+# GLOG_FOUND - system has Glog
+# GLOG_INCLUDE_DIRS - the Glog include directories
+# GLOG_LIBRARIES - link these to use Glog
+
+include(FindPackageHandleStandardArgs)
+find_path(
+  ZBD_INCLUDE_DIRS zbd.h
+  HINTS
+      $ENV{ZBD_ROOT}/include
+      ${ZBD_ROOT}/include
+)
+
+find_library(
+    ZBD_LIBRARIES zbd
+    HINTS
+        $ENV{ZBD_ROOT}/lib
+        ${ZBD_ROOT}/lib
+)
+
+# For some reason ZBD_FOUND is never marked as TRUE
+set(ZBD_FOUND TRUE)
+mark_as_advanced(ZBD_INCLUDE_DIRS ZBD_LIBRARIES)
+
+find_package_handle_standard_args(zbd ZBD_INCLUDE_DIRS ZBD_LIBRARIES)
+
+if(ZBD_FOUND AND NOT ZBD_FIND_QUIETLY)
+    message(STATUS "ZBD: ${ZBD_INCLUDE_DIRS}")
+endif()

--- a/cachelib/common/CMakeLists.txt
+++ b/cachelib/common/CMakeLists.txt
@@ -68,6 +68,7 @@ if (BUILD_TESTS)
     gflags
     GTest::gtest
     GTest::gtest_main
+    ${ZBD_LIBRARIES}
   )
 
   function (ADD_TEST SOURCE_FILE)

--- a/cachelib/compact_cache/CMakeLists.txt
+++ b/cachelib/compact_cache/CMakeLists.txt
@@ -22,6 +22,7 @@ if (BUILD_TESTS)
     gflags
     GTest::gtest
     GTest::gmock
+    ${ZBD_LIBRARIES}
   )
 
   function (ADD_TEST SOURCE_FILE)

--- a/cachelib/datatype/CMakeLists.txt
+++ b/cachelib/datatype/CMakeLists.txt
@@ -39,6 +39,7 @@ if (BUILD_TESTS)
     GTest::gtest
     GTest::gtest_main
     GTest::gmock
+    ${ZBD_LIBRARIES} 
   )
 
   function (ADD_TEST SOURCE_FILE)

--- a/cachelib/navy/CMakeLists.txt
+++ b/cachelib/navy/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library (cachelib_navy
   block_cache/Region.cpp
   block_cache/RegionManager.cpp
   common/Buffer.cpp
+  common/ZoneZbdAdapter.cpp
   common/Device.cpp
   common/Hash.cpp
   common/SizeDistribution.cpp
@@ -76,6 +77,7 @@ if (BUILD_TESTS)
     GTest::gtest
     GTest::gtest_main
     GTest::gmock
+    ${ZBD_LIBRARIES} 
   )
 
 

--- a/cachelib/navy/Factory.cpp
+++ b/cachelib/navy/Factory.cpp
@@ -481,4 +481,13 @@ std::unique_ptr<Device> createFileDevice(
                                   std::move(encryptor));
 }
 
+std::unique_ptr<Device> createZNSDevice(
+    std::string fileName,
+    uint64_t size,
+    uint32_t ioAlignSize,
+    std::shared_ptr<DeviceEncryptor> encryptor,
+    uint32_t maxDeviceWriteSize) {
+  return createDirectIoZNSDevice(fileName, size, ioAlignSize,
+                                  std::move(encryptor), maxDeviceWriteSize);
+}
 } // namespace facebook::cachelib::navy

--- a/cachelib/navy/Factory.h
+++ b/cachelib/navy/Factory.h
@@ -217,6 +217,12 @@ std::unique_ptr<Device> createFileDevice(
     IoEngine ioEngine,
     uint32_t qDepth,
     std::shared_ptr<navy::DeviceEncryptor> encryptor);
+	std::unique_ptr<Device> createZNSDevice(
+    std::string fileName,
+    uint64_t size,
+    uint32_t ioAlignSize,
+    std::shared_ptr<navy::DeviceEncryptor> encryptor,
+    uint32_t maxDeviceWriteSize);
 
 } // namespace navy
 } // namespace cachelib

--- a/cachelib/navy/block_cache/RegionManager.h
+++ b/cachelib/navy/block_cache/RegionManager.h
@@ -273,7 +273,7 @@ class RegionManager {
   void doFlushInternal(RegionId rid);
 
   bool deviceWrite(RelAddress addr, BufferView buf);
-
+  bool deviceReset(RelAddress addr, uint32_t size);
   bool isValidIORange(uint32_t offset, uint32_t size) const;
   std::pair<OpenStatus, std::unique_ptr<CondWaiter>> assignBufferToRegion(
       RegionId rid, bool addWaiter);

--- a/cachelib/navy/common/Device.h
+++ b/cachelib/navy/common/Device.h
@@ -154,6 +154,9 @@ class Device {
   // Returns the alignment size for device io operations
   uint32_t getIOAlignmentSize() const { return ioAlignmentSize_; }
 
+  virtual uint32_t reset(uint64_t offset, uint32_t size) const { return 0; }
+  virtual void setLayOutInfo(uint64_t blockCacheStart, uint64_t blockCacheSize, 
+    uint64_t bigHashStart, uint64_t bucketNum) const {};
  protected:
   virtual bool writeImpl(uint64_t offset, uint32_t size, const void* value) = 0;
   virtual bool readImpl(uint64_t offset, uint32_t size, void* value) = 0;
@@ -241,6 +244,12 @@ std::unique_ptr<Device> createDirectIoFileDevice(
     uint32_t maxDeviceWriteSize,
     std::shared_ptr<DeviceEncryptor> encryptor);
 
+std::unique_ptr<Device> createDirectIoZNSDevice(
+    std::string& fileName,
+    uint64_t size,
+    uint32_t ioAlignSize,
+    std::shared_ptr<DeviceEncryptor> encryptor,
+    uint32_t maxDeviceWriteSize);
 } // namespace navy
 } // namespace cachelib
 } // namespace facebook

--- a/cachelib/navy/common/ZoneZbdAdapter.cpp
+++ b/cachelib/navy/common/ZoneZbdAdapter.cpp
@@ -1,0 +1,609 @@
+
+#include <stdio.h>
+#include <cstring>
+#include <numeric>
+#include <iostream>
+#include "ZoneZbdAdapter.h"
+#include "cachelib/common/Time.h"
+
+namespace facebook {
+namespace cachelib {
+namespace navy {
+#define INVALID       0xFFFFFFFFFFFFFFFF
+#define INVALID_NODE  -1
+#define OPTIMAL_WRITE (16 * 4096)
+const int32_t REGION_ONE_WRITE = OPTIMAL_WRITE * ZONE_NUM_IN_NODE;
+struct WriteIoCB {
+  struct iocb cb;
+  int         index;
+  int*        complete;
+};
+
+struct ReadSeg {
+  void*    buf;
+  uint64_t offset;
+  uint64_t size;
+};
+
+ZoneZbdAdapter::~ZoneZbdAdapter() {
+  for (int i = 0; i < zoneNum_; i++) {
+    if (zones_[i].valid > 0 && zones_[i].wp != zones_[i].offset) {
+      uint64_t valid = zones_[i].valid;
+      cout << "~ZoneZbdAdapter " << i
+           << " all: " << zones_[i].wp - zones_[i].offset
+           << " valid: " << zones_[i].valid << " valid: "
+           << (zones_[i].wp - zones_[i].offset) -
+                  (zoneCapacity_ - zones_[i].valid)
+           << endl;
+    }
+  }
+
+  isRunning = false;
+  resetThread->join();
+  delete resetThread;
+  delete[] zones_;
+  if (mutex_) {
+    delete[] mutex_;
+  }
+  if (logicToPhyArr) {
+    delete[] logicToPhyArr;
+  }
+
+  if (nodes_) {
+    delete[] nodes_;
+  }
+
+  if (regionFTLArr) {
+    delete[] regionFTLArr;
+  }
+
+  int ret = io_destroy(ctx_);
+  if (ret < 0) {
+    printf("io_destroy: ret[%d] \n", ret);
+  }
+  zbd_close(readWriteF_);
+}
+
+bool ZoneZbdAdapter::openZoneDevice(const string& devName) {
+  struct zbd_info info;
+  readWriteF_ = zbd_open(devName.c_str(), O_RDWR | O_DIRECT, &info);
+  if (readWriteF_ < 0) {
+    printf("zbd_open: err readWriteF_[%d] \n", readWriteF_);
+    return false;
+  }
+
+  zoneNum_      = info.nr_zones;
+  zoneCapacity_ = info.zone_size;
+  blockSize_    = info.pblock_size;
+
+  uint64_t         addrSpaceSize = zoneNum_ * zoneCapacity_;
+  struct zbd_zone* zoneRep       = NULL;
+  uint32_t         reportZoneNum = 0;
+  int ret = zbd_list_zones(readWriteF_, 0, addrSpaceSize, ZBD_RO_ALL, &zoneRep,
+                           &reportZoneNum);
+  if (ret || reportZoneNum != zoneNum_) {
+    printf("zbd_list_zones : ret[%d] reportZoneNum[%u] != zoneNum_[%u] \n", ret,
+           reportZoneNum, zoneNum_);
+    return false;
+  }
+
+  zones_ = new zone[zoneNum_];
+  praseZoneInfo(zoneRep);
+  resetThread = new std::thread(&ZoneZbdAdapter::processReset, this);
+  isRunning   = true;
+
+  ret = io_setup(CTX_NUM, &ctx_);
+  if (ret) {
+    printf("writeAsync: io_setup failed ret[%d] \n", ret);
+  }
+
+  memset(events, 0, sizeof(events));
+  free(zoneRep);
+
+  return true;
+}
+
+void ZoneZbdAdapter::setLayOutInfo(uint64_t blockCacheStart, uint64_t blockCacheSize, 
+    uint64_t hashStart, uint64_t bucketNum) {
+  hashStart_     = hashStart;
+  blockStart_    = blockCacheStart;
+  hashZoneIndex_ = hashStart_ % zoneCapacity_ ? hashStart_ / zoneCapacity_ + 1
+                                              : hashStart_ / zoneCapacity_;
+  printf("ZoneZbdAdapter::setLayOutInfo blockCacheStart [%lu] blockCacheSize[%lu] hashStart_[%lu] "
+      "hashZoneIndex_[%lu] bucketNum[%llu]\n",
+      blockCacheStart, blockCacheSize, hashStart_, hashZoneIndex_, bucketNum);
+  for (int free = hashZoneIndex_; free < zoneNum_; free++) {
+    freeQue.push(free);
+  }
+
+  int num       = zoneNum_ - hashZoneIndex_;
+  mutex_        = new folly::SharedMutex[INDEX_PAREL_NUM];
+  logicToPhyArr = new uint64_t[bucketNum];
+  for (int i = 0; i < bucketNum; i++) {
+    logicToPhyArr[i] = INVALID;
+  }
+
+  uint64_t vzoneNum = blockCacheSize / ZONE_NUM_IN_NODE / zoneCapacity_ + 1;
+  nodes_            = new VZone[vzoneNum];
+  int nodeId        = 0;
+  for (uint32_t zoneId = 1; zoneId < hashZoneIndex_;) {
+    if (hashZoneIndex_ - zoneId < ZONE_NUM_IN_NODE) {
+      break;
+    }
+
+    struct VZone* vzone = &nodes_[nodeId];
+    vzone->usedSize     = 0;
+    vzone->validSize    = 0;
+    for (int tz = 0; tz < ZONE_NUM_IN_NODE; tz++) {
+      vzone->zones[tz] = zoneId++;
+    }
+    freeNodeQue.push(nodeId++);
+  }
+
+  uint64_t regionMetaNum = blockCacheSize / REGION_ONE_WRITE + 1;
+  regionFTLArr           = new RegionMeta[regionMetaNum];
+  for (uint64_t i = 0; i < regionMetaNum; i++) {
+    regionFTLArr[i].nodeId = INVALID_NODE;
+  }
+}
+
+bool ZoneZbdAdapter::readOffset(void* buf, uint64_t offset, uint64_t size) {
+  if (offset < hashStart_) {
+    return readRegion(buf, offset, size);
+  } else {
+    int      index     = (offset - hashStart_) / size;
+    uint64_t targetOff = offset;
+    {
+      std::unique_lock<folly::SharedMutex> lock{getMutex(index)};
+      targetOff = logicToPhyArr[index];
+    }
+
+    if (targetOff == INVALID) {
+      targetOff = offset;
+    }
+
+    return readSync(buf, targetOff, size);
+  }
+}
+
+bool ZoneZbdAdapter::writeOffset(const void* buf, uint64_t offset,
+                                 uint64_t size) {
+  if (offset < hashStart_) {
+    return writeAsync(buf, offset, size);
+  } else {
+    int      index     = (offset - hashStart_) / size;
+    uint64_t targetOff = offset;
+    {
+      std::unique_lock<folly::SharedMutex> lock{getMutex(index)};
+      targetOff = logicToPhyArr[index];
+    }
+
+    if (targetOff != INVALID) {
+      int zindex = targetOff / zoneCapacity_;
+      zones_[zindex].valid -= size;
+      if (zones_[zindex].valid == 0) {
+        resetMutex.lock();
+        resetQue.push(zindex);
+        resetMutex.unlock();
+      }
+    }
+
+    int zoneIndex = allocZone(size);
+    if (zoneIndex >= zoneNum_) {
+      printf("no zone!");
+      return false;
+    }
+
+    bool ret = writeSync(buf, zones_[zoneIndex].wp, size);
+    if (ret) {
+      std::unique_lock<folly::SharedMutex> lock{getMutex(index)};
+      logicToPhyArr[index] = zones_[zoneIndex].wp;
+      zones_[zoneIndex].wp += size;
+    }
+
+    repaidZone(zoneIndex);
+    zones_[zoneIndex].lock = 0;
+    return ret;
+  }
+}
+
+void ZoneZbdAdapter::praseZoneInfo(struct zbd_zone* rep) {
+  for (int i = 0; i < zoneNum_; i++) {
+    zone*            z     = &zones_[i];
+    struct zbd_zone* zInfo = &rep[i];
+    z->offset              = zInfo->start;
+    z->wp                  = zInfo->wp;
+    z->lock                = 0;
+    z->state               = zInfo->flags;
+    z->valid               = zoneCapacity_;
+  }
+}
+
+int ZoneZbdAdapter::allocZone(uint64_t size) {
+  const int ONCE_ALLOC = 5;
+  allocMutex.lock();
+  if (usedQue.empty()) {
+    int allocNum = 0;
+    while (!freeQue.empty() && allocNum < ONCE_ALLOC) {
+      usedQue.push(freeQue.front());
+      freeQue.pop();
+      allocNum++;
+    }
+  }
+
+  int allockId = zoneNum_;  // may dead circle
+  while (!usedQue.empty()) {
+    int i = usedQue.front();
+    usedQue.pop();
+    if (zones_[i].wp + size > zones_[i].offset + zoneCapacity_) {
+      usedQue.push(i);
+      continue;
+    }
+
+    allockId = i;
+    break;
+  }
+
+  if (allockId == zoneNum_) {
+    printf("no zoned avaliable!\n");
+  }
+  allocMutex.unlock();
+  return allockId;
+}
+
+void ZoneZbdAdapter::repaidZone(uint32_t zoneId, bool free) {
+  if (zones_[zoneId].wp < zones_[zoneId].offset + zoneCapacity_) {
+    allocMutex.lock();
+    if (free) {
+      freeQue.push(zoneId);
+    } else {
+      usedQue.push(zoneId);
+    }
+    allocMutex.unlock();
+  }
+}
+int ZoneZbdAdapter::allocNode(uint64_t size) {
+  const int ONCE_ALLOC = 5;
+  allocNodeMutex.lock();
+  if (usedNodeQue.empty()) {
+    int allocNum = 0;
+    while (!freeNodeQue.empty() && allocNum < ONCE_ALLOC) {
+      usedNodeQue.push(freeNodeQue.front());
+      freeNodeQue.pop();
+      allocNum++;
+    }
+  }
+
+  int allockId = -1;  // may dead circle
+  while (!usedNodeQue.empty()) {
+    int i = usedNodeQue.front();
+    usedNodeQue.pop();
+    if (nodes_[i].usedSize + size > ZONE_NUM_IN_NODE * zoneCapacity_) {
+      usedNodeQue.push(i);
+      continue;
+    }
+
+    allockId = i;
+    break;
+  }
+
+  if (allockId == -1) {
+    printf("no zoned avaliable!\n");
+  }
+  allocNodeMutex.unlock();
+  return allockId;
+}
+
+void ZoneZbdAdapter::repaidNode(int16_t nodeId) {
+  if (nodes_[nodeId].usedSize < ZONE_NUM_IN_NODE * zoneCapacity_) {
+    allocNodeMutex.lock();
+    usedNodeQue.push(nodeId);
+    allocNodeMutex.unlock();
+  }
+}
+
+bool ZoneZbdAdapter::readSync(void* buf, uint64_t offset, uint64_t size) {
+  if (offset % blockSize_ != 0 || size % blockSize_ != 0) {
+    printf("readSync:no allign buf[%p] offset[%lu] size[%lu]\n", buf, offset,
+           size);
+    return false;
+  }
+
+  int readSize = pread(readWriteF_, buf, size, offset);
+  if (readSize <= 0) {
+    printf("pread:err readSize[%d] buf[%p] offset[%lu] size[%lu]\n", readSize,
+           buf, offset, size);
+    return false;
+  }
+
+  return readSize == size;
+}
+
+bool ZoneZbdAdapter::writeSync(const void* buf, uint64_t offset,
+                               uint64_t size) {
+  if (offset % blockSize_ != 0 || size % blockSize_ != 0) {
+    printf("writeSync:no allign buf[%p] offset[%lu] size[%lu]\n", buf, offset,
+           size);
+    return false;
+  }
+
+  int ret = pwrite(readWriteF_, buf, size, offset);
+  if (ret < 0) {
+    printf("pwrite: err ret[%d] opaque [%p] offset[%lu] size[%lu]\n", ret, buf,
+           offset, size);
+    return false;
+  }
+  return size == ret;
+}
+
+void ZoneZbdAdapter::getWriteEvents(int* lock) {
+  struct timespec tms;
+  tms.tv_sec  = 0;
+  tms.tv_nsec = 100000000;
+  int r       = io_getevents(ctx_, 1, CTX_NUM, events, &tms);
+  if (r > 0) {
+    for (int j = 0; j < r; ++j) {
+      struct WriteIoCB* iocb = (struct WriteIoCB*)events[j].obj;
+      lock[iocb->index%ZONE_NUM_IN_NODE]      = 0;
+      int zoneId             = iocb->cb.u.c.offset / zoneCapacity_;
+      zones_[zoneId].wp += OPTIMAL_WRITE;
+      (*iocb->complete)++;
+    }
+  }
+}
+
+bool ZoneZbdAdapter::writeAsync(const void* buf, uint64_t offset,
+                                uint64_t size) {
+  if (offset % blockSize_ != 0 || size % blockSize_ != 0) {
+    printf("writeAsync:no allign buf[%p] offset[%lu] size[%lu]\n", buf, offset, size);
+    return false;
+  }
+
+  if ((size / OPTIMAL_WRITE != ZONE_NUM_IN_NODE) ||
+      (size % OPTIMAL_WRITE != 0)) {
+    printf("writeAsync: no strip buf[%p] offset[%lu] size[%lu] \n", buf, offset, size);
+    return false;
+  }
+
+  int16_t nodeId = allocNode(size);
+  if (nodeId == -1) {
+    printf("writeAsync:no nodeId buf[%p] offset[%lu] size[%lu] nodeId [%d]\n",
+           buf, offset, size, nodeId);
+    return false;
+  }
+
+  uint64_t startIndex =
+      nodes_[nodeId].usedSize / OPTIMAL_WRITE % ZONE_NUM_IN_NODE;
+  uint16_t num = size / OPTIMAL_WRITE;
+
+  vector<vector<struct WriteUnit>> writeUnites(ZONE_NUM_IN_NODE, vector<struct WriteUnit>());
+  for (int i = 0; i < num; i++) {
+    int                       j    = i % ZONE_NUM_IN_NODE;
+    vector<struct WriteUnit>& temp = writeUnites[j];
+    struct WriteUnit          wu;
+    wu.buf        = (void*)buf + i * OPTIMAL_WRITE;
+    wu.size       = OPTIMAL_WRITE;
+    wu.zoneId     = nodes_[nodeId].zones[(startIndex + i) % ZONE_NUM_IN_NODE];
+    wu.zoneOffset = temp.size() == 0 ? zones_[wu.zoneId].wp : temp[temp.size() - 1].zoneOffset + OPTIMAL_WRITE;
+    temp.push_back(wu);
+  }
+
+  struct WriteIoCB cbs[ZONE_NUM_IN_NODE];
+  memset(cbs, 0, sizeof(cbs));
+  int submit                        = 0;
+  int lock[ZONE_NUM_IN_NODE]        = {0};
+  int submitIndex[ZONE_NUM_IN_NODE] = {0};
+  int complete                      = 0;
+  for (int i = 0; i < ZONE_NUM_IN_NODE; i++) {
+    cbs[i].complete = &complete;
+  }
+
+  while (submit < num) {
+    for (int i = 0; i < num; i++) {
+      int j = i % ZONE_NUM_IN_NODE;
+      if (lock[j]) {
+        getWriteEvents(lock);
+        continue;
+      }
+
+      if (submitIndex[j] >= writeUnites[j].size()) {
+        continue;
+      }
+
+      struct WriteUnit& wu = writeUnites[j][submitIndex[j]];
+      io_prep_pwrite(&cbs[j].cb, readWriteF_, wu.buf, wu.size, wu.zoneOffset);
+      struct iocb* iocbs[1];
+      iocbs[0] = &cbs[j].cb;
+      int ret  = io_submit(ctx_, 1, iocbs);
+      if (ret != 1) {
+        getWriteEvents(lock);
+        printf("writeAsync: io_submit failed ret[%d] \n", ret);
+      } else {
+        submitIndex[j]++;
+        submit++;
+        lock[j] = 1;
+      }
+    }
+  }
+
+  while (complete < num) {
+    getWriteEvents(lock);
+    usleep(1);
+  }
+
+  RegionMeta rm;
+  rm.nodeId = nodeId;
+  rm.offset = nodes_[nodeId].usedSize;
+  nodes_[nodeId].usedSize += size;
+  nodes_[nodeId].validSize += size;
+  regionFTLArr[(offset - blockStart_) / size] = rm;
+  repaidNode(nodeId);
+
+  return true;
+}
+
+void ZoneZbdAdapter::splitRegionRead(void* buf, uint64_t offset, uint64_t size,
+                                     vector<struct ReadUnit>& rus) {
+  if (offset % blockSize_ != 0 || size % blockSize_ != 0) {
+    printf("readSync:no allign buf[%p] offset[%lu] size[%lu]\n", buf, offset, size);
+    return;
+  }
+
+  struct ReadSeg rseg;
+  rseg.buf    = buf;
+  rseg.offset = offset;
+  rseg.size   = size;
+
+  queue<ReadSeg> rsegQue;
+  rsegQue.push(rseg);
+  while (!rsegQue.empty()) {
+    rseg = rsegQue.front();
+    rsegQue.pop();
+    uint32_t blockOff = rseg.offset % (REGION_ONE_WRITE);
+    if (blockOff + rseg.size > REGION_ONE_WRITE) {
+      uint64_t       rsize = REGION_ONE_WRITE - blockOff;
+      struct ReadSeg trseg;
+      trseg.buf    = rseg.buf + rsize;
+      trseg.offset = rseg.offset + rsize;
+      trseg.size   = rseg.size - rsize;
+      rsegQue.push(trseg);
+      rseg.size = rsize;
+    }
+
+    int blockIndex = (rseg.offset - blockStart_) / REGION_ONE_WRITE;
+    if (regionFTLArr[blockIndex].nodeId == -1) {
+      printf("splitRegionRead: no meta tid[%lu] buf[%p] offset[%lu] size[%lu]\n",
+          std::this_thread::get_id(), rseg.buf, rseg.offset, rseg.size);
+      continue;
+    }
+
+    uint64_t nodeOffset = regionFTLArr[blockIndex].offset;
+    uint16_t nodeId     = regionFTLArr[blockIndex].nodeId;
+    uint64_t readOffset = nodeOffset + blockOff;
+    uint16_t level      = readOffset / REGION_ONE_WRITE;
+    uint32_t zoneIndex  = readOffset / OPTIMAL_WRITE % ZONE_NUM_IN_NODE;
+    uint64_t zoneOff    = zones_[nodes_[nodeId].zones[zoneIndex]].offset +
+                       OPTIMAL_WRITE * level + readOffset % OPTIMAL_WRITE;
+    uint64_t singleZoneReadLen =
+        rseg.size < (OPTIMAL_WRITE - readOffset % OPTIMAL_WRITE)
+            ? rseg.size : (OPTIMAL_WRITE - readOffset % OPTIMAL_WRITE);
+    uint64_t remainLen = rseg.size;
+    void*    tmpBuf    = rseg.buf;
+    while (remainLen > 0) {
+      struct ReadUnit ru;
+      ru.buf        = tmpBuf;
+      ru.zoneOffset = zoneOff;
+      ru.size       = singleZoneReadLen;
+      rus.push_back(ru);
+      remainLen -= singleZoneReadLen;
+      tmpBuf += singleZoneReadLen;
+      zoneIndex = (zoneIndex + 1) % ZONE_NUM_IN_NODE;
+      if (zoneIndex == 0) {
+        level++;
+      }
+
+      zoneOff = zones_[nodes_[nodeId].zones[zoneIndex]].offset +
+                OPTIMAL_WRITE * level;
+      singleZoneReadLen = OPTIMAL_WRITE > remainLen ? remainLen : OPTIMAL_WRITE;
+    }
+  }
+}
+
+bool ZoneZbdAdapter::readRegion(void* buf, uint64_t offset, uint64_t size) {
+  vector<struct ReadUnit> rus;
+  splitRegionRead(buf, offset, size, rus);
+  int readComplete = 0;
+  for (int i = 0; i < rus.size(); i++) {
+    int readSize =
+        pread(readWriteF_, rus[i].buf, rus[i].size, rus[i].zoneOffset);
+    if (readSize <= 0) {
+      return false;
+    }
+    readComplete += readSize;
+  }
+
+  return readComplete == size;
+}
+
+int ZoneZbdAdapter::resetRegion(uint64_t offset, uint64_t len) {
+ // printf("resetRegion: offset[%lu] len[%lu]\n", offset, len);
+  uint64_t toffset = offset - blockStart_;
+  for (uint64_t temp = toffset; temp < toffset + len; temp += REGION_ONE_WRITE) {
+    RegionMeta* rm = &regionFTLArr[temp / REGION_ONE_WRITE];
+    if (rm->nodeId == INVALID_NODE) {
+      continue;
+    }
+
+    nodes_[rm->nodeId].validSize -= REGION_ONE_WRITE;
+    if (nodes_[rm->nodeId].validSize == 0 &&
+        nodes_[rm->nodeId].usedSize == ZONE_NUM_IN_NODE * zoneCapacity_) {
+      for (int i = 0; i < ZONE_NUM_IN_NODE; i++) {
+        resetZone(zones_[nodes_[rm->nodeId].zones[i]].offset, zoneCapacity_);
+      }
+      repaidNode(rm->nodeId);
+    }
+    rm->nodeId = INVALID_NODE;
+  }
+
+  return 0;
+}
+
+int ZoneZbdAdapter::resetZone(uint64_t offset, uint64_t len) {
+  // printf("resetZone: offset[%lu] len[%lu]\n",  offset, len);
+  if (len != 0) {
+    int index = offset / zoneCapacity_;
+    int max   = index + len / zoneCapacity_;
+    for (; index < max; index++) {
+      int ret = zbd_reset_zones(readWriteF_, zones_[index].offset, zoneCapacity_);
+      if (ret) {
+        printf("resetZone: failed ret[%d] offset[%lu] len[%lu]\n", ret, offset, len);
+      }
+
+      zones_[index].wp    = zones_[index].offset;
+      zones_[index].lock  = 0;
+      zones_[index].valid = zoneCapacity_;
+      if (index >= hashZoneIndex_) {
+        repaidZone(index, true);
+      }
+    }
+  } else {
+    printf("reset BigHash [%d]\n", offset);
+    int index = offset % zoneCapacity_ ? offset / zoneCapacity_ + 1
+                                       : offset / zoneCapacity_;
+    for (; index < zoneNum_; index++) {
+      if (zones_[index].wp != zones_[index].offset) {
+        int ret =
+            zbd_reset_zones(readWriteF_, zones_[index].offset, zoneCapacity_);
+        if (ret) {
+          printf("zbd reset ret[%d] offset[%lu] len[%lu]\n", ret, zones_[index].offset, zoneCapacity_);
+        }
+        printf("reset index[%d]\n", index);
+        zones_[index].wp    = zones_[index].offset;
+        zones_[index].lock  = 0;
+        zones_[index].valid = zoneCapacity_;
+      }
+    }
+  }
+
+  return 0;
+}
+
+void ZoneZbdAdapter::processReset() {
+  while (isRunning) {
+    usleep(1);
+    resetMutex.lock();
+    if (resetQue.empty()) {
+      resetMutex.unlock();
+      continue;
+    }
+
+    int i = resetQue.front();
+    resetQue.pop();
+    resetMutex.unlock();
+    resetZone(zones_[i].offset, zoneCapacity_);
+  }
+}
+
+}  // namespace navy
+}  // namespace cachelib
+}  // namespace facebook

--- a/cachelib/navy/common/ZoneZbdAdapter.h
+++ b/cachelib/navy/common/ZoneZbdAdapter.h
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <map>
+#include <thread>
+#include <queue>
+#include <mutex>
+#include <atomic>
+#include <fcntl.h>
+#include <libaio.h>
+#include <folly/File.h>
+#include <folly/SharedMutex.h>
+#include <libzbd/zbd.h>
+
+using namespace std;
+namespace facebook {
+namespace cachelib {
+namespace navy {
+const uint64_t INDEX_PAREL_NUM = 128 * 1024;
+const uint64_t ZONE_NUM_IN_NODE = 16;
+#define CTX_NUM 1024
+
+struct zone {
+  uint64_t         offset;
+  uint64_t         wp;
+  atomic<uint64_t> valid;
+  uint8_t          lock;
+  uint8_t          state;
+};
+
+struct VZone {
+  uint32_t         zones[ZONE_NUM_IN_NODE];
+  uint32_t         usedSize;
+  atomic<uint64_t> validSize;
+  uint8_t          status;
+};
+
+struct RegionMeta {
+  int16_t  nodeId;
+  uint32_t offset;
+};
+
+struct WriteUnit {
+  void*    buf;
+  uint64_t zoneOffset;
+  uint32_t zoneId;
+  uint32_t size;
+};
+
+struct ReadUnit {
+  void*    buf;
+  uint64_t zoneOffset;
+  uint32_t size;
+};
+
+class ZoneZbdAdapter {
+ public:
+  ZoneZbdAdapter() {
+    hashStart_    = 0;
+    blockStart_   = 0;
+    readWriteF_   = -1;
+    zones_        = nullptr;
+    mutex_        = nullptr;
+    logicToPhyArr = nullptr;
+    ctx_          = nullptr;
+    nodes_        = nullptr;
+    regionFTLArr  = nullptr;
+    zoneNum_      = 0;
+    zoneCapacity_ = 0;
+    blockSize_    = 0;
+    hashZoneIndex_= 0;
+    isRunning     = false;
+    resetThread   = nullptr;
+  }
+
+  virtual ~ZoneZbdAdapter();
+
+  bool openZoneDevice(const string& devName);
+
+  bool readOffset(void* buf, uint64_t offset, uint64_t size);
+
+  bool writeOffset(const void* buf, uint64_t offset, uint64_t size);
+
+  void setLayOutInfo(uint64_t blockCacheStart, uint64_t blockCacheSize, uint64_t hashStart,
+                     uint64_t bucketNum);
+
+  int resetZone(uint64_t offset, uint64_t len);
+
+  int resetRegion(uint64_t offset, uint64_t len);
+
+ private:
+  void praseZoneInfo(struct zbd_zone* rep);
+
+  int allocZone(uint64_t size);
+
+  void repaidZone(uint32_t zoneId, bool free = false);
+
+  int allocNode(uint64_t size);
+
+  void repaidNode(int16_t nodeId);
+
+  bool readSync(void* buf, uint64_t offset, uint64_t size);
+
+  bool writeSync(const void* buf, uint64_t offset, uint64_t size);
+
+  void processReset();
+
+  void getWriteEvents(int* lock);
+
+  bool writeAsync(const void* buf, uint64_t offset, uint64_t size);
+
+  void splitRegionRead(void* buf, uint64_t offset, uint64_t size,
+                       vector<struct ReadUnit>& rus);
+
+  bool readRegion(void* buf, uint64_t offset, uint64_t size);
+
+  folly::SharedMutex& getMutex(uint32_t zid) const {
+    return mutex_[zid & (INDEX_PAREL_NUM - 1)];
+  }
+
+  int          readWriteF_;
+  struct zone* zones_;
+
+  queue<uint32_t> freeQue;
+  queue<uint32_t> usedQue;
+  std::mutex      allocMutex;
+
+  struct VZone*      nodes_;
+  queue<uint16_t>    freeNodeQue;
+  queue<uint16_t>    usedNodeQue;
+  std::mutex         allocNodeMutex;
+  struct RegionMeta* regionFTLArr;
+
+  uint32_t zoneNum_;
+  uint64_t zoneCapacity_;
+  uint32_t blockSize_;
+  uint32_t hashZoneIndex_;
+  uint64_t hashStart_;
+  uint64_t blockStart_;
+
+  uint64_t*           logicToPhyArr;
+  folly::SharedMutex* mutex_;
+
+  std::thread*    resetThread;
+  queue<uint32_t> resetQue;
+  std::mutex      resetMutex;
+  bool            isRunning;
+
+  io_context_t    ctx_;
+  struct io_event events[CTX_NUM];
+};
+
+}  // namespace navy
+}  // namespace cachelib
+}  // namespace facebook


### PR DESCRIPTION
This PR adds the support for CacheLib working on ZNS SSD. With the chnages, the CacheLib is able to reduce the device-side write amplification (WA) and TCO in hybrid storage cache (DRAM and NVMe SSD).

For BlockCache object, the LOC region is configured to be aligned with the zone size, when the region is evicted, the zone is reclaimed (explicit reset command) as well, there is no valid data movement by GC. To enhance the performance, the PR also implements data striping approach. Multipe zones are grouped as a region and the data are striped into multiple slices then write into zones.

For BigHash, set is configured to align with ZNS SSD page size (e.g. 4KB). When the zone is filled with set, allocate a new zone to store sets. While all sets are evicted, the zone is reclaimed fore reuse.

The PR introduces a new class ZNSDevice in device layer to support ZNS SSD with regular block interface semantics.

| ops  | Conventional SSD | ZNS SSD   |
| :--: | ---------------- | --------- |
| get  | 479,400/s        | 479,970/s |
| set  | 61,857/s         | 61,930/s  |
| del  | 2,997/s          | 3,001/s   |