### PR TITLE
Binary request generator/replayer

### DIFF
--- a/cachelib/cachebench/CMakeLists.txt
+++ b/cachelib/cachebench/CMakeLists.txt
@@ -41,6 +41,25 @@ target_link_libraries(cachelib_cachebench PUBLIC
   gflags
 )
 
+add_library (cachelib_binary_trace_gen
+  ./runner/Runner.cpp
+  ./runner/Stressor.cpp
+  ./util/CacheConfig.cpp
+  ./util/Config.cpp
+  ./workload/BlockChunkCache.cpp
+  ./workload/BlockChunkReplayGenerator.cpp
+  ./workload/PieceWiseCache.cpp
+  ./workload/OnlineGenerator.cpp
+  ./workload/WorkloadGenerator.cpp
+  ./workload/PieceWiseReplayGenerator.cpp
+  )
+add_dependencies(cachelib_binary_trace_gen thrift_generated_files)
+target_link_libraries(cachelib_binary_trace_gen PUBLIC
+  cachelib_datatype
+  cachelib_allocator
+  gflags
+)
+
 if ((CMAKE_SYSTEM_NAME STREQUAL Linux) AND
     (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64))
 else()
@@ -49,11 +68,14 @@ endif()
 
 
 add_executable (cachebench main.cpp)
+add_executable (binary_trace_gen binary_trace_gen.cpp)
 target_link_libraries(cachebench cachelib_cachebench)
+target_link_libraries(binary_trace_gen cachelib_binary_trace_gen)
 
 install(
   TARGETS
      cachebench
+     binary_trace_gen
   DESTINATION ${BIN_INSTALL_DIR}
 )
 

--- a/cachelib/cachebench/binary_trace_gen.cpp
+++ b/cachelib/cachebench/binary_trace_gen.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/io/async/EventBase.h>
+#include <folly/logging/LoggerDB.h>
+#include <gflags/gflags.h>
+
+#include <memory>
+#include <thread>
+
+#include "cachelib/cachebench/workload/KVReplayGenerator.h"
+#include "cachelib/common/Utils.h"
+
+#include <folly/init/Init.h>
+#include <gflags/gflags.h>
+
+DEFINE_string(json_test_config,
+              "",
+              "path to test config. If empty, use default setting");
+DEFINE_uint64(
+    progress,
+    60,
+    "if set, prints progress every X seconds as configured, 0 to disable");
+
+
+bool checkArgsValidity() {
+  if (FLAGS_json_test_config.empty() ||
+      !facebook::cachelib::util::pathExists(FLAGS_json_test_config)) {
+    std::cout << "Invalid config file: " << FLAGS_json_test_config
+              << ". pass a valid --json_test_config for trace generation."
+              << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
+int main(int argc, char** argv) {
+  using namespace facebook::cachelib;
+  using namespace facebook::cachelib::cachebench;
+
+  folly::init(&argc, &argv, true);
+  if (!checkArgsValidity()) {
+    return 1;
+  }
+
+  CacheBenchConfig config(FLAGS_json_test_config);
+  std::cout << "Binary Trace Generator" << std::endl;
+
+  try {
+    auto generator = 
+        std::make_unique<KVReplayGenerator>(config.getStressorConfig());
+  } catch (const std::exception& e) {
+    std::cout << "Invalid configuration. Exception: " << e.what() << std::endl;
+    return 1;
+  }
+
+  return 0;
+}

--- a/cachelib/cachebench/runner/Stressor.cpp
+++ b/cachelib/cachebench/runner/Stressor.cpp
@@ -22,6 +22,7 @@
 #include "cachelib/cachebench/runner/FastShutdown.h"
 #include "cachelib/cachebench/runner/IntegrationStressor.h"
 #include "cachelib/cachebench/workload/BlockChunkReplayGenerator.h"
+#include "cachelib/cachebench/workload/BinaryKVReplayGenerator.h"
 #include "cachelib/cachebench/workload/KVReplayGenerator.h"
 #include "cachelib/cachebench/workload/OnlineGenerator.h"
 #include "cachelib/cachebench/workload/PieceWiseReplayGenerator.h"
@@ -145,6 +146,8 @@ std::unique_ptr<GeneratorBase> makeGenerator(const StressorConfig& config) {
     return std::make_unique<KVReplayGenerator>(config);
   } else if (config.generator == "block-replay") {
     return std::make_unique<BlockChunkReplayGenerator>(config);
+  } else if (config.generator == "binary-replay") {
+    return std::make_unique<BinaryKVReplayGenerator>(config);
   } else if (config.generator.empty() || config.generator == "workload") {
     // TODO: Remove the empty() check once we label workload-based configs
     // properly

--- a/cachelib/cachebench/test_configs/trace_replay/kvcache/config_kvtrace_gen_binary.json
+++ b/cachelib/cachebench/test_configs/trace_replay/kvcache/config_kvtrace_gen_binary.json
@@ -1,0 +1,13 @@
+{
+  "test_config":
+  {
+    "generator": "replay",
+    "replayGeneratorConfig":
+    {
+      "binaryFileName": "kv_trace.bin"
+    },    
+    "repeatTraceReplay": false,
+    "repeatOpCount" : true,
+    "traceFileName": "kv_traces_1.csv"
+  }
+}

--- a/cachelib/cachebench/test_configs/trace_replay/kvcache/config_kvtrace_replay_binary.json
+++ b/cachelib/cachebench/test_configs/trace_replay/kvcache/config_kvtrace_replay_binary.json
@@ -1,0 +1,27 @@
+{
+  "cache_config":
+  {
+    "cacheSizeMB": 500,
+    "cacheDir": "/tmp/cachelib_metadata",
+    "allocFactor": 1.08,
+    "maxAllocSize": 524288,
+    "minAllocSize": 64,
+    "htBucketPower": 29,
+    "moveOnSlabRelease": false,
+    "poolRebalanceIntervalSec": 2,
+    "poolResizeIntervalSec": 1,
+    "rebalanceStrategy": "hits"
+  },
+  "test_config":
+  {
+    "generator": "binary-replay",
+    "repeatTraceReplay": false,
+    "repeatOpCount" : true,
+    "onlySetIfMiss" : false,
+    "timestampFactor": 1,
+    "numOps": 2000000,
+    "numThreads": 16,
+    "prepopulateCache": true,
+    "traceFileName": "kv_trace.bin"
+  }
+}

--- a/cachelib/cachebench/util/Config.cpp
+++ b/cachelib/cachebench/util/Config.cpp
@@ -90,7 +90,7 @@ StressorConfig::StressorConfig(const folly::dynamic& configJson) {
   // If you added new fields to the configuration, update the JSONSetVal
   // to make them available for the json configs and increment the size
   // below
-  checkCorrectSize<StressorConfig, 512>();
+  checkCorrectSize<StressorConfig, 560>();
 }
 
 bool StressorConfig::usesChainedItems() const {
@@ -134,9 +134,11 @@ CacheBenchConfig::CacheBenchConfig(
   stressorConfig_ = stressorConfigCustomizer
                         ? stressorConfigCustomizer(stressorConfig)
                         : stressorConfig;
-  auto cacheConfig = CacheConfig{configJson["cache_config"]};
-  cacheConfig_ =
-      cacheConfigCustomizer ? cacheConfigCustomizer(cacheConfig) : cacheConfig;
+  if (configJson.count("cache_config")) {
+    auto cacheConfig = CacheConfig{configJson["cache_config"]};
+    cacheConfig_ =
+        cacheConfigCustomizer ? cacheConfigCustomizer(cacheConfig) : cacheConfig;
+  }
 }
 
 DistributionConfig::DistributionConfig(const folly::dynamic& jsonConfig,
@@ -197,6 +199,10 @@ DistributionConfig::DistributionConfig(const folly::dynamic& jsonConfig,
 
 ReplayGeneratorConfig::ReplayGeneratorConfig(const folly::dynamic& configJson) {
   JSONSetVal(configJson, ampFactor);
+  JSONSetVal(configJson, ampSizeFactor);
+  JSONSetVal(configJson, binaryFileName);
+  JSONSetVal(configJson, fastForwardCount);
+  JSONSetVal(configJson, preLoadReqs);
   JSONSetVal(configJson, replaySerializationMode);
   JSONSetVal(configJson, relaxedSerialIntervalMs);
   JSONSetVal(configJson, numAggregationFields);
@@ -217,7 +223,7 @@ ReplayGeneratorConfig::ReplayGeneratorConfig(const folly::dynamic& configJson) {
         "Unsupported request serialization mode: {}", replaySerializationMode));
   }
 
-  checkCorrectSize<ReplayGeneratorConfig, 136>();
+  checkCorrectSize<ReplayGeneratorConfig, 184>();
 }
 
 ReplayGeneratorConfig::SerializeMode

--- a/cachelib/cachebench/util/Config.h
+++ b/cachelib/cachebench/util/Config.h
@@ -124,7 +124,24 @@ struct ReplayGeneratorConfig : public JSONConfig {
   };
   std::string replaySerializationMode{"strict"};
 
+  // amplifies the number of unique keys by
+  // a factor. each key gets amplified by
+  // ampFactor times
   uint32_t ampFactor{1};
+  // amplifies the object size by a factor
+  uint32_t ampSizeFactor{1};
+
+  // the path of the binary file to make
+  std::string binaryFileName{};
+
+  // The number of requests (not including ampFactor) to skip
+  // in the trace. This is so that after warming up the cache
+  // with a certain number of requests, we can easily reattach
+  // and resume execution with different cache configurations.
+  uint64_t fastForwardCount{0};
+
+  // The number of requests to pre load into the request queues
+  uint64_t preLoadReqs{0};
 
   // The time interval threshold when replaySerializationMode is relaxed.
   uint64_t relaxedSerialIntervalMs{500};

--- a/cachelib/cachebench/util/Request.h
+++ b/cachelib/cachebench/util/Request.h
@@ -60,6 +60,35 @@ enum class OpResultType {
   kCouldExistFalse
 };
 
+struct BinaryRequest {
+  uint8_t keySize_;
+  uint8_t op_;
+  uint16_t repeats_;
+  uint16_t ttl_;
+  uint64_t keyOffset_;
+  uint32_t valueSize_;
+
+  BinaryRequest() = default;
+
+  BinaryRequest(uint8_t keySize,
+                size_t valueSize,
+                uint16_t repeats,
+                uint8_t op,
+                uint16_t ttl,
+                size_t keyOffset)
+      : keySize_(keySize),
+        valueSize_(valueSize),
+        repeats_(repeats),
+        op_(op),
+        ttl_(ttl),
+        keyOffset_(keyOffset) {}
+
+  std::string_view getKey() const {
+    return std::string_view(reinterpret_cast<const char*>(this) + keyOffset_,
+                            keySize_);
+  }
+};
+
 struct Request {
   Request(std::string& k,
           std::vector<size_t>::iterator b,
@@ -78,6 +107,9 @@ struct Request {
           OpType o,
           uint64_t reqId)
       : key(k), sizeBegin(b), sizeEnd(e), requestId(reqId), op(o) {}
+
+  Request(std::string_view k, size_t* b, OpType o, uint64_t reqId)
+      : key(k), sizeBegin(b), sizeEnd(b), requestId(reqId), op(o) {}
 
   Request(std::string& k,
           std::vector<size_t>::iterator b,
@@ -121,12 +153,24 @@ struct Request {
 
   Request(Request&& r) noexcept
       : key(r.key), sizeBegin(r.sizeBegin), sizeEnd(r.sizeEnd) {}
-  Request& operator=(Request&& r) = delete;
+  Request& operator=(Request&&) = delete;
 
+  inline void update(std::string_view k,
+                     size_t* valueSize,
+                     OpType o,
+                     uint16_t ttl,
+                     uint64_t reqId) {
+    key = k;
+    op = o;
+    ttlSecs = ttl;
+    requestId = reqId;
+    sizeBegin = std::vector<size_t>::iterator(valueSize);
+    sizeEnd = std::vector<size_t>::iterator(valueSize);
+  }
   OpType getOp() const noexcept { return op.load(); }
   void setOp(OpType o) noexcept { op = o; }
 
-  std::string& key;
+  std::string_view key;
 
   // size iterators in case this request is
   // deemed to be a chained item.
@@ -137,7 +181,7 @@ struct Request {
   // TTL in seconds.
   uint32_t ttlSecs{0};
 
-  const std::optional<uint64_t> requestId;
+  std::optional<uint64_t> requestId;
 
   // Feature map for this request sample, which is used for for admission
   // policy: feature name --> feature value

--- a/cachelib/cachebench/workload/BinaryKVReplayGenerator.h
+++ b/cachelib/cachebench/workload/BinaryKVReplayGenerator.h
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Conv.h>
+#include <folly/ProducerConsumerQueue.h>
+#include <folly/ThreadLocal.h>
+#include <folly/lang/Aligned.h>
+#include <folly/logging/xlog.h>
+#include <folly/synchronization/Latch.h>
+#include <folly/system/ThreadName.h>
+
+#include "cachelib/cachebench/cache/Cache.h"
+#include "cachelib/cachebench/util/Exceptions.h"
+#include "cachelib/cachebench/util/Parallel.h"
+#include "cachelib/cachebench/util/Request.h"
+#include "cachelib/cachebench/workload/ReplayGeneratorBase.h"
+
+namespace facebook {
+namespace cachelib {
+namespace cachebench {
+
+// BinaryKVReplayGenerator generates the cachelib requests based on the
+// requests read from the given binary trace file made with KVReplayGenerator
+// In order to minimize the contentions for the request submission queues
+// which might need to be dispatched by multiple stressor threads,
+// the requests are sharded to each stressor by doing hashing over the key.
+class BinaryKVReplayGenerator : public ReplayGeneratorBase {
+ public:
+  explicit BinaryKVReplayGenerator(const StressorConfig& config)
+      : ReplayGeneratorBase(config), binaryStream_(config, numShards_) {
+    for (uint32_t i = 0; i < numShards_; ++i) {
+      stressorCtxs_.emplace_back(
+          std::make_unique<StressorCtx>(i, fastForwardCount_));
+    }
+
+    XLOGF(INFO,
+          "Started BinaryKVReplayGenerator (# of stressor threads {}, total "
+          "requests {})",
+          numShards_, binaryStream_.getNumReqs());
+  }
+
+  virtual ~BinaryKVReplayGenerator() { XCHECK(shouldShutdown()); }
+
+  // getReq generates the next request from the trace file.
+  const Request& getReq(
+      uint8_t,
+      std::mt19937_64&,
+      std::optional<uint64_t> lastRequestId = std::nullopt) override;
+
+  void renderStats(uint64_t, std::ostream& out) const override {
+    out << std::endl << "== BinaryKVReplayGenerator Stats ==" << std::endl;
+  }
+
+  void markFinish() override { getStressorCtx().markFinish(); }
+
+ private:
+  // per thread: the number of requests to run through
+  // the trace before jumping to next offset
+  static constexpr size_t kRunLength = 10000;
+
+  // StressorCtx keeps track of the state including the submission queues
+  // per stressor thread. Since there is only one request generator thread,
+  // lock-free ProducerConsumerQueue is used for performance reason.
+  // Also, separate queue which is dispatched ahead of any requests in the
+  // submission queue is used for keeping track of the requests which need to be
+  // resubmitted (i.e., a request having remaining repeat count); there could
+  // be more than one requests outstanding for async stressor while only one
+  // can be outstanding for sync stressor
+  struct StressorCtx {
+    explicit StressorCtx(uint32_t id, uint32_t fastForwardCount)
+        : id_(id), reqIdx_(id * kRunLength + fastForwardCount),
+          request_(std::string_view("abc"),
+                   reinterpret_cast<size_t*>(0), 
+                   OpType::kGet, 
+                   0),
+          runIdx_(0) {}
+
+    bool isFinished() { return finished_.load(std::memory_order_relaxed); }
+    void markFinish() { finished_.store(true, std::memory_order_relaxed); }
+    void resetIdx() { reqIdx_ = id_ * kRunLength; }
+
+    Request request_;
+    uint64_t reqIdx_{0};
+    uint32_t id_{0};
+    uint64_t runIdx_{0};
+    // Thread that finish its operations mark it here, so we will skip
+    // further request on its shard
+    std::atomic<bool> finished_{false};
+  };
+
+  // Used to assign stressorIdx_
+  std::atomic<uint32_t> incrementalIdx_{0};
+
+  // A sticky index assigned to each stressor threads that calls into
+  // the generator.
+  folly::ThreadLocalPtr<uint32_t> stressorIdx_;
+
+  // Vector size is equal to the # of stressor threads;
+  // stressorIdx_ is used to index.
+  std::vector<std::unique_ptr<StressorCtx>> stressorCtxs_;
+
+  // Class that holds a vector of pointers to the
+  // binary data
+  BinaryFileStream binaryStream_;
+
+  // Used to signal end of file as EndOfTrace exception
+  std::atomic<bool> eof{false};
+
+  void setEOF() { eof.store(true, std::memory_order_relaxed); }
+  bool isEOF() { return eof.load(std::memory_order_relaxed); }
+
+  inline StressorCtx& getStressorCtx(size_t shardId) {
+    XCHECK_LT(shardId, numShards_);
+    return *stressorCtxs_[shardId];
+  }
+
+  inline StressorCtx& getStressorCtx() {
+    if (!stressorIdx_.get()) {
+      stressorIdx_.reset(new uint32_t(incrementalIdx_++));
+    }
+
+    return getStressorCtx(*stressorIdx_);
+  }
+};
+
+const Request& BinaryKVReplayGenerator::getReq(uint8_t,
+                                               std::mt19937_64& gen,
+                                               std::optional<uint64_t>) {
+  auto& stressorCtx = getStressorCtx();
+  auto& r = stressorCtx.request_;
+  BinaryRequest* prevReq = reinterpret_cast<BinaryRequest*>(*(r.requestId));
+  if (prevReq != nullptr && prevReq->repeats_ > 1) {
+    prevReq->repeats_ = prevReq->repeats_ - 1;
+  } else {
+    BinaryRequest* req = nullptr;
+    try {
+      req = binaryStream_.getNextPtr(stressorCtx.reqIdx_ + stressorCtx.runIdx_);
+    } catch (const EndOfTrace& e) {
+      if (config_.repeatTraceReplay) {
+        stressorCtx.resetIdx();
+        req = binaryStream_.getNextPtr(stressorCtx.reqIdx_ + stressorCtx.runIdx_);
+      } else {
+        setEOF();
+        throw cachelib::cachebench::EndOfTrace("Test stopped or EOF reached");
+      }
+    }
+
+    XDCHECK_NE(req, nullptr);
+    XDCHECK_NE(reinterpret_cast<uint64_t>(req), 0);
+    XDCHECK_LT(req->op_, 12);
+    auto key = req->getKey();
+    OpType op = static_cast<OpType>(req->op_);
+    req->valueSize_ = (req->valueSize_) * ampSizeFactor_;
+    r.update(key,
+             const_cast<size_t*>(reinterpret_cast<size_t*>(&req->valueSize_)),
+             op,
+             req->ttl_,
+             reinterpret_cast<uint64_t>(req));
+    if (stressorCtx.runIdx_ < kRunLength) {
+      stressorCtx.runIdx_++;
+    } else {
+      stressorCtx.runIdx_ = 0;
+      stressorCtx.reqIdx_ += numShards_ * kRunLength;
+    }
+  }
+  return r;
+}
+
+} // namespace cachebench
+} // namespace cachelib
+} // namespace facebook

--- a/cachelib/cachebench/workload/KVReplayGenerator.h
+++ b/cachelib/cachebench/workload/KVReplayGenerator.h
@@ -21,6 +21,7 @@
 #include <folly/ThreadLocal.h>
 #include <folly/lang/Aligned.h>
 #include <folly/logging/xlog.h>
+#include <folly/synchronization/Latch.h>
 #include <folly/system/ThreadName.h>
 
 #include "cachelib/cachebench/cache/Cache.h"
@@ -32,6 +33,8 @@
 namespace facebook {
 namespace cachelib {
 namespace cachebench {
+
+#define BIN_REQ_INT 100000000
 
 struct ReqWrapper {
   ReqWrapper() = default;
@@ -97,15 +100,76 @@ class KVReplayGenerator : public ReplayGeneratorBase {
     for (uint32_t i = 0; i < numShards_; ++i) {
       stressorCtxs_.emplace_back(std::make_unique<StressorCtx>(i));
     }
+    if (!binaryFileName_.empty()) {
+      makeBinaryFile_ = true;
+    }
+    folly::Latch latch(1);
+    if (makeBinaryFile_) {
+      std::string filePath;
+      if (binaryFileName_[0] == '/') {
+        filePath = binaryFileName_;
+      } else {
+        filePath = folly::sformat("{}/{}", config.configPath, binaryFileName_);
+      }
+      int fd = open(filePath.c_str(), O_RDWR | O_CREAT | O_TRUNC,
+                    S_IRUSR | S_IWUSR);
+      // first get the number of requests
+      auto traceInfo = traceStream_.getTraceRequestStats();
+      if (traceInfo.first == 0 && traceInfo.second == 0) {
+        close(fd);
+        exit(1);
+      }
+      auto nreqs = traceInfo.first * ampFactor_;
+      auto totalKeySize = traceInfo.second * ampFactor_;
+      XLOGF(INFO,
+            "Started generating binary file from KVReplayGenerator"
+            "(amp factor {}, size factor {}, trace requests {})",
+            ampFactor_, ampSizeFactor_, traceInfo.first);
+      totalReqs_ = nreqs;
+      size_t binReqSize = sizeof(BinaryRequest);
+      size_t totalSize = sizeof(size_t) + nreqs * binReqSize + totalKeySize + 1;
+      size_t totalSizeP =
+          totalSize + (PG_SIZE - totalSize % PG_SIZE); // page align
+      ftruncate(fd, totalSizeP);
+      void* memory =
+          mmap(nullptr, totalSizeP, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+      void* copy = memory;
+      // the first entry is the total number of requests in the file, so we can
+      // calculate the key offset
+      size_t* first = reinterpret_cast<size_t*>(memory);
+      std::memcpy(first, &nreqs, sizeof(size_t));
+      first++;
+      memory = reinterpret_cast<void*>(first);
+      outputStreamReqs_ = reinterpret_cast<BinaryRequest*>(memory);
+      outputStreamKeys_ = reinterpret_cast<char*>(memory);
+      outputStreamKeys_ += nreqs * binReqSize;
+      folly::setThreadName("cb_binary_gen");
+      traceStream_.fastForwardTrace(fastForwardCount_);
+      genRequests(latch);
+      int res = msync(copy, totalSizeP, MS_SYNC);
+      if (res != 0) {
+        XLOGF(INFO, "msync error {}", res);
+      }
+      res = munmap(copy, totalSizeP);
+      if (res != 0) {
+        XLOGF(INFO, "unmap error {}", res);
+      }
+      close(fd);
+      exit(0);
+    } else {
+      genWorker_ = std::thread([this, &latch] {
+        folly::setThreadName("cb_replay_gen");
+        traceStream_.fastForwardTrace(fastForwardCount_);
+        genRequests(latch);
+      });
+    }
 
-    genWorker_ = std::thread([this] {
-      folly::setThreadName("cb_replay_gen");
-      genRequests();
-    });
+    latch.wait();
 
     XLOGF(INFO,
-          "Started KVReplayGenerator (amp factor {}, # of stressor threads {})",
-          ampFactor_, numShards_);
+          "Started KVReplayGenerator (amp factor {}, # of stressor threads {}, "
+          "fast forward {})",
+          ampFactor_, numShards_, fastForwardCount_);
   }
 
   virtual ~KVReplayGenerator() {
@@ -191,6 +255,10 @@ class KVReplayGenerator : public ReplayGeneratorBase {
   std::vector<std::unique_ptr<StressorCtx>> stressorCtxs_;
 
   TraceFileStream traceStream_;
+  BinaryRequest* outputStreamReqs_;
+  char* outputStreamKeys_;
+  size_t totalReqs_;
+  bool makeBinaryFile_{false};
 
   std::thread genWorker_;
 
@@ -201,7 +269,7 @@ class KVReplayGenerator : public ReplayGeneratorBase {
   std::atomic<uint64_t> parseError = 0;
   std::atomic<uint64_t> parseSuccess = 0;
 
-  void genRequests();
+  void genRequests(folly::Latch& latch);
 
   void setEOF() { eof.store(true, std::memory_order_relaxed); }
   bool isEOF() { return eof.load(std::memory_order_relaxed); }
@@ -306,12 +374,22 @@ inline std::unique_ptr<ReqWrapper> KVReplayGenerator::getReqInternal() {
   return reqWrapper;
 }
 
-inline void KVReplayGenerator::genRequests() {
+inline void KVReplayGenerator::genRequests(folly::Latch& latch) {
+  bool init = true;
+  uint64_t nreqs = 0;
+  size_t keyOffset = 0;
+  size_t lastKeyOffset = 0;
+  size_t keyAddr;
+  auto begin = util::getCurrentTimeSec();
+  auto binReqStart = util::getCurrentTimeSec();
   while (!shouldShutdown()) {
     std::unique_ptr<ReqWrapper> reqWrapper;
     try {
       reqWrapper = getReqInternal();
     } catch (const EndOfTrace&) {
+      if (init) {
+        latch.count_down();
+      }
       break;
     }
 
@@ -324,6 +402,7 @@ inline void KVReplayGenerator::genRequests() {
         req = std::make_unique<ReqWrapper>(*reqWrapper);
       }
 
+      size_t keySize = req->key_.size();
       if (ampFactor_ > 1) {
         // Replace the last 4 bytes with thread Id of 4 decimal chars. In doing
         // so, keep at least 10B from the key for uniqueness; 10B is the max
@@ -336,15 +415,76 @@ inline void KVReplayGenerator::genRequests() {
         req->key_.append(folly::sformat("{:04d}", keySuffix));
       }
 
-      auto shardId = getShard(req->req_.key);
-      auto& stressorCtx = getStressorCtx(shardId);
-      auto& reqQ = *stressorCtx.reqQueue_;
+      if (makeBinaryFile_) {
+        uint8_t op = static_cast<uint8_t>(req->req_.getOp());
+        auto valueSize = req->sizes_[0] * ampSizeFactor_;
+        // calculate the offset for the key relative to position of current
+        // request
+        uint64_t relKeyOffset =
+            reinterpret_cast<uint64_t>(outputStreamKeys_ + keyOffset) -
+            reinterpret_cast<uint64_t>(outputStreamReqs_ + nreqs);
+        auto binReq = BinaryRequest(keySize, valueSize, req->repeats_, op,
+                                    req->req_.ttlSecs, relKeyOffset);
+        // copy the binary request struct to the output stream (mmap'd file)
+        std::memcpy(outputStreamReqs_ + nreqs, &binReq, sizeof(binReq));
+        // copy the key to the output stream for keys (same mmap'd file, but at
+        // different offset)
+        std::memcpy(outputStreamKeys_ + keyOffset, req->key_.c_str(), keySize);
+        if ((nreqs % BIN_REQ_INT) == 0 && nreqs > 0) {
+          auto end = util::getCurrentTimeSec();
+          double reqsPerSec = BIN_REQ_INT / (double)(end - binReqStart);
 
-      while (!reqQ.write(std::move(req)) && !stressorCtx.isFinished() &&
-             !shouldShutdown()) {
-        // ProducerConsumerQueue does not support blocking, so use sleep
-        std::this_thread::sleep_for(
-            std::chrono::microseconds{checkIntervalUs_});
+          uint64_t reqStart = reinterpret_cast<uint64_t>(outputStreamReqs_ +
+                                                         (nreqs - BIN_REQ_INT));
+          reqStart = reqStart + (PG_SIZE - reqStart % PG_SIZE);
+          uint64_t reqEnd =
+              reinterpret_cast<uint64_t>(outputStreamReqs_ + nreqs);
+          reqEnd = reqEnd + (PG_SIZE - reqEnd % PG_SIZE);
+          int rres = madvise(reinterpret_cast<void*>(reqStart),
+                             reqEnd - reqStart, MADV_DONTNEED);
+          XDCHECK_EQ(rres, 0);
+
+          uint64_t keyStart =
+              reinterpret_cast<uint64_t>(outputStreamKeys_ + lastKeyOffset);
+          keyStart = keyStart + (PG_SIZE - keyStart % PG_SIZE);
+          uint64_t keyEnd =
+              reinterpret_cast<uint64_t>(outputStreamKeys_ + keyOffset);
+          keyEnd = keyEnd + (PG_SIZE - keyEnd % PG_SIZE);
+
+          int kres = madvise(reinterpret_cast<void*>(keyStart),
+                             keyEnd - keyStart, MADV_DONTNEED);
+          XDCHECK_EQ(kres, 0);
+
+          XLOGF(INFO, "Parsed: {} reqs ({:.2f} reqs/sec)", nreqs, reqsPerSec);
+          lastKeyOffset = keyOffset;
+          binReqStart = util::getCurrentTimeSec();
+        }
+        nreqs++;
+        keyOffset += keySize;
+      } else {
+        auto shardId = getShard(req->req_.key);
+        auto& stressorCtx = getStressorCtx(shardId);
+        auto& reqQ = *stressorCtx.reqQueue_;
+
+        while (!reqQ.write(std::move(req)) && !stressorCtx.isFinished() &&
+               !shouldShutdown()) {
+          // ProducerConsumerQueue does not support blocking, so use sleep
+          if (init) {
+            latch.count_down();
+            init = false;
+          }
+          std::this_thread::sleep_for(
+              std::chrono::microseconds{checkIntervalUs_});
+        }
+        nreqs++;
+      }
+
+      if (nreqs >= preLoadReqs_ && init) {
+        auto end = util::getCurrentTimeSec();
+        double reqsPerSec = nreqs / (double)(end - begin);
+        XLOGF(INFO, "Parse rate: {:.2f} reqs/sec", reqsPerSec);
+        latch.count_down();
+        init = false;
       }
     }
   }

--- a/cachelib/cachebench/workload/OnlineGenerator.cpp
+++ b/cachelib/cachebench/workload/OnlineGenerator.cpp
@@ -55,10 +55,12 @@ const Request& OnlineGenerator::getReq(uint8_t poolId,
                                        std::optional<uint64_t>) {
   size_t keyIdx = getKeyIdx(poolId, gen);
 
-  generateKey(poolId, keyIdx, req_->key);
+  std::string key(req_->key);
+  generateKey(poolId, keyIdx, key);
   auto sizes = generateSize(poolId, keyIdx);
   req_->sizeBegin = sizes->begin();
   req_->sizeEnd = sizes->end();
+  req_->key = key;
   auto op =
       static_cast<OpType>(workloadDist_[workloadIdx(poolId)].sampleOpDist(gen));
   req_->setOp(op);

--- a/cachelib/cachebench/workload/PieceWiseReplayGenerator.h
+++ b/cachelib/cachebench/workload/PieceWiseReplayGenerator.h
@@ -45,7 +45,10 @@ class PieceWiseReplayGenerator : public ReplayGeneratorBase {
       threadFinished_[i].store(false, std::memory_order_relaxed);
     }
 
-    traceGenThread_ = std::thread([this]() { getReqFromTrace(); });
+    traceGenThread_ = std::thread([this]() {
+      traceStream_.fastForwardTrace(fastForwardCount_);
+      getReqFromTrace();
+    });
   }
 
   virtual ~PieceWiseReplayGenerator() {

--- a/cachelib/cachebench/workload/ReplayGeneratorBase.h
+++ b/cachelib/cachebench/workload/ReplayGeneratorBase.h
@@ -16,9 +16,15 @@
 
 #pragma once
 
+#include <errno.h>
+#include <fcntl.h>
 #include <folly/Format.h>
 #include <folly/Random.h>
 #include <folly/logging/xlog.h>
+#include <folly/synchronization/DistributedMutex.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <cstdint>
@@ -30,14 +36,17 @@
 
 #include "cachelib/cachebench/util/Config.h"
 #include "cachelib/cachebench/util/Exceptions.h"
+#include "cachelib/cachebench/util/Request.h"
 #include "cachelib/cachebench/workload/GeneratorBase.h"
+
+#define PG_SIZE 4096
 
 namespace facebook {
 namespace cachelib {
 namespace cachebench {
 
+constexpr size_t kPgRelease = 100000000;
 constexpr size_t kIfstreamBufferSize = 1L << 14;
-
 // ColumnInfo is to pass the information required to parse the trace
 // to map the column to the replayer-specific field ID.
 struct ColumnInfo {
@@ -83,6 +92,81 @@ class TraceFileStream {
     }
 
     return infile_;
+  }
+
+  // Returns the total number of requests in the trace
+  // plus the average key size so we can properly
+  // set up the binary file stream via mmap
+  //
+  // We return a pair, the first value is the number
+  // of lines in the trace and the second value is the
+  // average key size
+  std::pair<uint64_t, uint64_t> getTraceRequestStats() {
+    uint64_t lines = 0;
+    uint64_t totalKeySize = 0;
+    const std::string& traceFileName = infileNames_[0];
+    std::string filePath;
+    if (traceFileName[0] == '/') {
+      filePath = traceFileName;
+    } else {
+      filePath = folly::sformat("{}/{}", configPath_, traceFileName);
+    }
+
+    std::ifstream file;
+    std::string line;
+    file.open(filePath);
+    if (file.fail()) {
+      XLOGF(ERR, "Failed to open trace file {}", filePath);
+      return std::make_pair(0, 0);
+    }
+
+    XLOGF(INFO, "Opened trace file {}", filePath);
+    bool first = true;
+    while (std::getline(file, line)) {
+      if (first) {
+        setHeaderRow(line);
+        first = false;
+      } else {
+        // Default order is key,op,size,op_count,key_size,ttl
+        nextLineFields_.clear();
+        folly::split(",", line, nextLineFields_);
+
+        if (nextLineFields_.size() < minNumFields_) {
+          XLOG_N_PER_MS(INFO, 10, 1000) << folly::sformat(
+              "Error parsing next line \"{}\": shorter than min required "
+              "fields {}",
+              line, minNumFields_);
+        }
+        auto keySizeField = getField<size_t>(2); 
+        if (!keySizeField.hasValue()) {
+          XLOG_N_PER_MS(INFO, 10, 1000) << folly::sformat(
+              "Error parsing next line \"{}\": key size not found");
+        } else {
+          // The key is encoded as <encoded key, key size>.
+          size_t keySize = keySizeField.value();
+          // The key size should not exceed 256
+          keySize = std::min<size_t>(keySize, 256);
+          totalKeySize += keySize;
+          lines++;
+        }
+      }
+    }
+    file.close();
+
+    return std::make_pair(lines, totalKeySize);
+  }
+
+  // The number of requests (not including ampFactor) to skip
+  // in the trace. This is so that after warming up the cache
+  // with a certain number of requests, we can easily reattach
+  // and resume execution with different cache configurations.
+  void fastForwardTrace(uint64_t fastForwardCount) {
+    uint64_t count = 0;
+    while (count < fastForwardCount) {
+      std::string line;
+      this->getline(line); // can throw
+      count++;
+    }
   }
 
   bool setNextLine(const std::string& line) {
@@ -211,11 +295,11 @@ class TraceFileStream {
 
     infile_.open(filePath);
     if (infile_.fail()) {
-      XLOGF(ERR, "{} Failed to open trace file {}", idStr_, traceFileName);
+      XLOGF(ERR, "{} Failed to open trace file {}", idStr_, filePath);
       return false;
     }
 
-    XLOGF(INFO, "{} Opened trace file {}", idStr_, traceFileName);
+    XLOGF(INFO, "{} Opened trace file {}", idStr_, filePath);
     infile_.rdbuf()->pubsetbuf(infileBuffer_, sizeof(infileBuffer_));
     // header
     std::string headerLine;
@@ -255,6 +339,128 @@ class TraceFileStream {
   std::vector<folly::StringPiece> nextLineFields_;
 
   std::vector<std::string> keys_;
+  uint64_t lines_ = 0;
+};
+
+class BinaryFileStream {
+ public:
+  BinaryFileStream(const StressorConfig& config, const uint32_t numShards)
+      : infileName_(config.traceFileName) {
+
+    std::string filePath;
+    if (infileName_[0] == '/') {
+      filePath = infileName_;
+    } else {
+      filePath = folly::sformat("{}/{}", config.configPath, infileName_);
+    }
+    fd_ = open(filePath.c_str(), O_RDONLY);
+    // Get the size of the file
+    struct stat fileStat;
+    if (fstat(fd_, &fileStat) == -1) {
+      close(fd_);
+      XLOGF(INFO, "Error reading file size {}", filePath);
+    }
+    size_t* binaryData = reinterpret_cast<size_t*>(
+        mmap(nullptr, fileStat.st_size, PROT_READ | PROT_WRITE, MAP_PRIVATE,
+             fd_, 0));
+
+    // binary data pg align save for releasing old requests
+    pgBinaryData_ = reinterpret_cast<void*>(binaryData);
+
+    // first value is the number of requests in the file
+    nreqs_ = binaryData[0];
+    binaryData++;
+    // next is the request data
+    binaryReqData_ = reinterpret_cast<BinaryRequest*>(binaryData);
+    binaryKeyData_ = reinterpret_cast<char*>(binaryData);
+
+    // keys are stored after request structures
+    binaryKeyData_ += nreqs_ * sizeof(BinaryRequest);
+    // save the pg aligned key space for releasing old key data
+    pgBinaryKeyData_ = reinterpret_cast<void*>(
+        reinterpret_cast<uint64_t>(binaryKeyData_) +
+        (PG_SIZE - (reinterpret_cast<uint64_t>(binaryKeyData_) % PG_SIZE)));
+
+    releaseCount_ = 1; // release data after first nRelease reqs
+    nRelease_ = kPgRelease;
+    releaseIdx_ = nRelease_ * releaseCount_;
+  }
+
+  ~BinaryFileStream() { close(fd_); }
+
+  uint64_t getNumReqs() { return nreqs_; }
+
+  void releaseOldData(uint64_t reqsCompleted) {
+    // The number of bytes from the key data stream to release
+    uint64_t keyBytes =
+        (reinterpret_cast<uint64_t>(binaryReqData_ + releaseIdx_) +
+         binaryReqData_[releaseIdx_].keyOffset_) -
+        reinterpret_cast<uint64_t>(binaryKeyData_);
+
+    int kres = madvise(reinterpret_cast<void*>(pgBinaryKeyData_), keyBytes,
+                       MADV_DONTNEED);
+    if (kres != 0) {
+      XLOGF(INFO, "Failed to release old keys, key bytes: {}, result: {}",
+            keyBytes, strerror(errno));
+      XDCHECK_EQ(kres, 0);
+    } else {
+      XLOGF(INFO, "Release old keys, key bytes: {}", keyBytes);
+    }
+
+    int reqRes = madvise(reinterpret_cast<void*>(pgBinaryData_),
+                         (releaseIdx_) * sizeof(BinaryRequest) + sizeof(size_t),
+                         MADV_DONTNEED);
+
+    XDCHECK_EQ(reqRes, 0);
+    if (reqRes != 0) {
+      XLOGF(INFO,
+            "Failed to release old requests, released: {}, completed: {}, "
+            "result: {}",
+            releaseIdx_, reqsCompleted, strerror(errno));
+    } else {
+      XLOGF(INFO, "Released old requests, released: {}, completed: {}",
+            releaseIdx_, reqsCompleted);
+    }
+
+    releaseIdx_ = nRelease_ * (++releaseCount_);
+  }
+
+  BinaryRequest* getNextPtr(uint64_t reqIdx) {
+    if ((reqIdx > releaseIdx_) && (reqIdx % nRelease_ == 0)) {
+      releaseOldData(reqIdx);
+    }
+    if (reqIdx >= nreqs_) {
+      releaseCount_ = 1;
+      releaseIdx_ = nRelease_ * releaseCount_;
+      throw cachelib::cachebench::EndOfTrace("");
+    }
+    BinaryRequest* binReq = binaryReqData_ + reqIdx;
+    XDCHECK_LT(binReq->op_, 12);
+    return binReq;
+  }
+
+ private:
+  const StressorConfig config_;
+  std::string infileName_;
+
+  // pointers to mmaped data
+  BinaryRequest* binaryReqData_;
+  char* binaryKeyData_;
+
+  // these two pointers are to madvise
+  // away old request data
+  void* pgBinaryKeyData_;
+  void* pgBinaryData_;
+
+  // number of requests released so far
+  size_t releaseIdx_;
+  size_t releaseCount_;
+  // how often to release old requests
+  size_t nRelease_;
+
+  size_t fileSize_;
+  uint64_t nreqs_;
+  int fd_;
 };
 
 class ReplayGeneratorBase : public GeneratorBase {
@@ -263,6 +469,10 @@ class ReplayGeneratorBase : public GeneratorBase {
       : config_(config),
         repeatTraceReplay_{config_.repeatTraceReplay},
         ampFactor_(config.replayGeneratorConfig.ampFactor),
+        ampSizeFactor_(config.replayGeneratorConfig.ampSizeFactor),
+        binaryFileName_(config.replayGeneratorConfig.binaryFileName),
+        fastForwardCount_(config.replayGeneratorConfig.fastForwardCount),
+        preLoadReqs_(config.replayGeneratorConfig.preLoadReqs),
         timestampFactor_(config.timestampFactor),
         numShards_(config.numThreads),
         mode_(config_.replayGeneratorConfig.getSerializationMode()) {
@@ -280,7 +490,10 @@ class ReplayGeneratorBase : public GeneratorBase {
   const StressorConfig config_;
   const bool repeatTraceReplay_;
   const size_t ampFactor_;
-
+  const size_t ampSizeFactor_;
+  const uint64_t fastForwardCount_;
+  const uint64_t preLoadReqs_;
+  const std::string binaryFileName_;
   // The constant to be divided from the timestamp value
   // to turn the timestamp into seconds.
   const uint64_t timestampFactor_{1};


### PR DESCRIPTION
This is the binary trace replayer/generator that we have been using to achieve max CPU utilization for the kvcache traces in cachebench. With this generator, we can achieve a throughput of over 20 million op/sec using kvcache workload in cachebench. As a comparison, using the CSV replay generator we see only ~1.6 million op/sec due to dynamic allocations and parsing overhead.

We avoid allocations by mmap'ing the request data into memory and using a Request pointer to point to the request data rather than allocating a new request wrapper for each request.

To generate a binary request file from an existing kvcache trace (using the "replay" generator).
1. Specify the kvcache trace name using the regular `traceFileNames` or `traceFileName` option. Specify other properties such as ampFactor too.
2. In the replayGeneratorConfig, specify `binaryFileName: "mybinaryfile.bin` as a config option
3. Run cachebench and wait for the binary file to be generated

To run a binary request trace specify the following:
1. Set generator to "binary-replay"
2. Set `traceFileName: "mybinaryfile.bin"` and set ampSizeFactor (if desired)


In summary - this patch offers much lower overhead of trace replaying. It does assumes the kvcache trace format and kvcache replay generator behavior. Additional features:
- fast forwarding of a trace
- preloading requests into memory
- object size amplification
- queue free for even lower request overhead

The limitations are:
- no trace amplification (however you can amplify the
original .csv trace and save it in binary format)
- ~4GB overhead per 100 million requests
- you need some disk space to store large traces