### PR TITLE
Adding Unit Tests for FdpNvme class

### DIFF
--- a/cachelib/navy/common/FdpNvme.h
+++ b/cachelib/navy/common/FdpNvme.h
@@ -93,6 +93,12 @@ class NvmeData {
   NvmeData() = default;
   NvmeData& operator=(const NvmeData&) = default;
 
+  NvmeData(const NvmeData& data)
+      : nsId_(data.nsId_),
+        lbaShift_(data.lbaShift_),
+        maxTfrSize_(data.maxTfrSize_),
+        startLba_(data.startLba_) {}
+
   explicit NvmeData(int nsId,
                     uint32_t lbaShift,
                     uint32_t maxTfrSize,
@@ -131,6 +137,10 @@ class NvmeData {
 class FdpNvme {
  public:
   explicit FdpNvme(const std::string& fileName);
+
+  // This constructor allows user to experiment with FdpNvme without having the
+  // actual FDP device. Ex: FDP Unit Tests
+  explicit FdpNvme(NvmeData& data, struct nvme_fdp_ruh_status* ruh_status);
 
   FdpNvme(const FdpNvme&) = delete;
   FdpNvme& operator=(const FdpNvme&) = delete;
@@ -181,8 +191,8 @@ class FdpNvme {
   // Reads NvmeData for a NVMe device
   NvmeData readNvmeInfo(const std::string& blockDevice);
 
-  // Initialize the FDP device and populate necessary info.
-  void initializeFDP(const std::string& blockDevice);
+  // This function populate placement handles of the FDP device
+  void initializeFDPHandles(struct nvme_fdp_ruh_status* ruh_status);
 
   // Generic NVMe IO mgmnt receive cmd
   int nvmeIOMgmtRecv(uint32_t nsid,

--- a/cachelib/navy/common/tests/DeviceTest.cpp
+++ b/cachelib/navy/common/tests/DeviceTest.cpp
@@ -17,13 +17,16 @@
 #include <folly/File.h>
 #include <folly/Random.h>
 #include <folly/ScopeGuard.h>
+#include <folly/experimental/io/IoUring.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstring>
 #include <thread>
 
 #include "cachelib/common/Utils.h"
 #include "cachelib/navy/common/Device.h"
+#include "cachelib/navy/common/FdpNvme.h"
 #include "cachelib/navy/testing/BufferGen.h"
 #include "cachelib/navy/testing/Callbacks.h"
 #include "cachelib/navy/testing/MockDevice.h"
@@ -194,6 +197,79 @@ TEST(Device, Stats) {
   EXPECT_CALL(visitor, call(strPiece("navy_device_decryption_errors"), 0));
   EXPECT_CALL(visitor, call(strPiece("navy_device_write_latency_us_max"), 0));
   device.getCounters({toCallback(visitor)});
+}
+
+// Test for FdpNvme Constructor
+TEST(FDP, InitializationTest) {
+  int nsId = 1;
+  uint32_t lbaShift = 12;
+  uint32_t maxTfrSize = 262144;
+  uint64_t startLba = 0;
+  uint32_t numRuhs = 10;
+
+  NvmeData data(nsId, lbaShift, maxTfrSize, startLba);
+  struct nvme_fdp_ruh_status* ruh_status{};
+  Buffer buffer{sizeof(struct nvme_fdp_ruh_status) +
+                (numRuhs * sizeof(struct nvme_fdp_ruh_status_desc))};
+  ruh_status = reinterpret_cast<nvme_fdp_ruh_status*>(buffer.data());
+  ruh_status->nruhsd = numRuhs;
+  EXPECT_NO_THROW(FdpNvme fdp = FdpNvme(data, ruh_status));
+}
+
+// Test the Fdp Handle allocation
+TEST(FDP, FdpHandleAllocationTest) {
+  int nsId = 1;
+  uint32_t lbaShift = 12;
+  uint32_t maxTfrSize = 262144;
+  uint64_t startLba = 0;
+  uint32_t numRuhs = 10;
+
+  NvmeData data(nsId, lbaShift, maxTfrSize, startLba);
+  struct nvme_fdp_ruh_status* ruh_status{};
+  Buffer buffer{sizeof(struct nvme_fdp_ruh_status) +
+                (numRuhs * sizeof(struct nvme_fdp_ruh_status_desc))};
+  ruh_status = reinterpret_cast<nvme_fdp_ruh_status*>(buffer.data());
+  ruh_status->nruhsd = numRuhs;
+  FdpNvme fdp = FdpNvme(data, ruh_status);
+  for (auto i = 1; i < ruh_status->nruhsd; i++) {
+    EXPECT_EQ(i, fdp.allocateFdpHandle());
+  }
+
+  EXPECT_EQ(0, fdp.allocateFdpHandle());
+}
+
+// Test IO uring read, write command preparation
+TEST(FDP, PrepUringTest) {
+  int nsId = 1;
+  uint32_t lbaShift = 12;
+  uint32_t maxTfrSize = 262144;
+  uint64_t startLba = 0;
+  uint32_t numRuhs = 10;
+
+  NvmeData data(nsId, lbaShift, maxTfrSize, startLba);
+  struct nvme_fdp_ruh_status* ruh_status{};
+  Buffer buffer{sizeof(struct nvme_fdp_ruh_status) +
+                (numRuhs * sizeof(struct nvme_fdp_ruh_status_desc))};
+  ruh_status = reinterpret_cast<nvme_fdp_ruh_status*>(buffer.data());
+  ruh_status->nruhsd = numRuhs;
+  FdpNvme fdp = FdpNvme(data, ruh_status);
+  std::unique_ptr<folly::IoUringOp> iouringCmdOp;
+  folly::IoUringOp::Options options;
+  options.sqe128 = true;
+  options.cqe32 = true;
+
+  iouringCmdOp = std::make_unique<folly::IoUringOp>(
+      folly::AsyncBaseOp::NotificationCallback(), options);
+  iouringCmdOp->initBase();
+  struct io_uring_sqe& sqe = iouringCmdOp->getSqe();
+
+  void* buf{};
+  size_t size = 8192;
+  off_t start = 0;
+  int handle = 1;
+
+  EXPECT_NO_THROW(fdp.prepReadUringCmdSqe(sqe, buf, size, start));
+  EXPECT_NO_THROW(fdp.prepWriteUringCmdSqe(sqe, buf, size, start, handle));
 }
 
 struct DeviceParamTest


### PR DESCRIPTION
This commit adds the unit test cases for "FdpNvme" class.
It also adds a new constructor for FdpNvme. The existing constructor of FdpNvme communicates with the actual FDP device and makes the unit tests impossible to run without the actual device. So this commit adds a new constructor which allows to experiment with "FdpNvme" without the actual FDP device.