### PR TITLE
Use MockDevice.cpp when building navy, move code within #ifdefn 

### DIFF
--- a/cachelib/navy/CMakeLists.txt
+++ b/cachelib/navy/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library (cachelib_navy
   scheduler/ThreadPoolJobScheduler.cpp
   scheduler/ThreadPoolJobQueue.cpp
   serialization/RecordIO.cpp
+  testing/MockDevice.cpp
   )
 add_dependencies(cachelib_navy thrift_generated_files)
 
@@ -57,6 +58,7 @@ endif()
 
 target_link_libraries(cachelib_navy PUBLIC
   cachelib_common
+  GTest::gmock
   )
 
 install(TARGETS cachelib_navy

--- a/cachelib/navy/common/tests/DeviceTest.cpp
+++ b/cachelib/navy/common/tests/DeviceTest.cpp
@@ -296,23 +296,7 @@ TEST(Device, Stats) {
   device.getCounters({toCallback(visitor)});
 }
 
-// Test for FdpNvme Constructor
-TEST(FDP, InitializationTest) {
-  int nsId = 1;
-  uint32_t lbaShift = 12;
-  uint32_t maxTfrSize = 262144;
-  uint64_t startLba = 0;
-  uint32_t numRuhs = 10;
-
-  NvmeData data(nsId, lbaShift, maxTfrSize, startLba);
-  struct nvme_fdp_ruh_status* ruh_status{};
-  Buffer buffer{sizeof(struct nvme_fdp_ruh_status) +
-                (numRuhs * sizeof(struct nvme_fdp_ruh_status_desc))};
-  ruh_status = reinterpret_cast<nvme_fdp_ruh_status*>(buffer.data());
-  ruh_status->nruhsd = numRuhs;
-  EXPECT_NO_THROW(FdpNvme fdp = FdpNvme(data, ruh_status));
-}
-
+#ifndef CACHELIB_IOURING_DISABLE
 // Test the Fdp Handle allocation
 TEST(FDP, FdpHandleAllocationTest) {
   int nsId = 1;
@@ -334,7 +318,22 @@ TEST(FDP, FdpHandleAllocationTest) {
 
   EXPECT_EQ(0, fdp.allocateFdpHandle());
 }
+// Test for FdpNvme Constructor
+TEST(FDP, InitializationTest) {
+  int nsId = 1;
+  uint32_t lbaShift = 12;
+  uint32_t maxTfrSize = 262144;
+  uint64_t startLba = 0;
+  uint32_t numRuhs = 10;
 
+  NvmeData data(nsId, lbaShift, maxTfrSize, startLba);
+  struct nvme_fdp_ruh_status* ruh_status{};
+  Buffer buffer{sizeof(struct nvme_fdp_ruh_status) +
+                (numRuhs * sizeof(struct nvme_fdp_ruh_status_desc))};
+  ruh_status = reinterpret_cast<nvme_fdp_ruh_status*>(buffer.data());
+  ruh_status->nruhsd = numRuhs;
+  EXPECT_NO_THROW(FdpNvme fdp = FdpNvme(data, ruh_status));
+}
 // Test IO uring read, write command preparation
 TEST(FDP, PrepUringTest) {
   int nsId = 1;
@@ -368,6 +367,7 @@ TEST(FDP, PrepUringTest) {
   EXPECT_NO_THROW(fdp.prepReadUringCmdSqe(sqe, buf, size, start));
   EXPECT_NO_THROW(fdp.prepWriteUringCmdSqe(sqe, buf, size, start, handle));
 }
+#endif
 
 struct DeviceParamTest
     : public testing::TestWithParam<std::tuple<IoEngine, int>> {


### PR DESCRIPTION
This pull request addresses two build failures in the CacheLib repository:

1. Navy library MockDevice integration

The navy library recently started using MockDevice, but the build was failing due to missing API calls. This was caused by MockDevice.cpp not being included in the build process, and gmock not being linked.

Changes made:
- Added MockDevice.cpp to the build process for navy
- Linked gmock library to resolve missing API calls

2. Sizeof on incomplete types within conditional compilation blocks

FDP test code was using `sizeof` on types that were defined within `#ifdef` blocks, causing compilation errors when those blocks were not active. It is also has different variable name in some class based on #ifdef. It made sense to move the tests within the block.

Changes made:
- Moved test code calling `sizeof` on conditionally defined types inside the relevant `#ifdef` blocks
- Specifically, code within `#ifdef SOME_FLAG` now includes both the type definitions and the code using `sizeof` on those types.