### PR TITLE
Fix 'missing CacheAllocator.cpp' during build

### DIFF
--- a/cachelib/allocator/CMakeLists.txt
+++ b/cachelib/allocator/CMakeLists.txt
@@ -27,7 +27,14 @@ add_library (cachelib_allocator
   ${SERIALIZE_THRIFT_FILES}
   ${DATASTRUCT_SERIALIZE_THRIFT_FILES}
   ${MEMORY_SERIALIZE_THRIFT_FILES}
-    CacheAllocator.cpp
+    CacheAllocatorLru2QCache.cpp
+    CacheAllocatorLru5B2QCache.cpp
+    CacheAllocatorLru5BCache.cpp
+    CacheAllocatorLru5BCacheWithSpinBuckets.cpp
+    CacheAllocatorLruCache.cpp
+    CacheAllocatorLruCacheWithSpinBuckets.cpp
+    CacheAllocatorTinyLFU5BCache.cpp
+    CacheAllocatorTinyLFUCache.cpp
     Cache.cpp
     CacheDetails.cpp
     CacheStats.cpp


### PR DESCRIPTION
Fix #345.
However, the build still failed due to the Navy misusing folly functions.