### PR TITLE
fix compiler errors for main and tests

### DIFF
--- a/.github/workflows/build-cachelib-centos-9.yml
+++ b/.github/workflows/build-cachelib-centos-9.yml
@@ -78,6 +78,8 @@ jobs:
         run: ./contrib/build-package.sh -j -v -i sparsemap
       - name: "Install dependency: fmt"
         run: ./contrib/build-package.sh -j -v -i fmt
+      - name: "Install dependency: fastfloat"
+        run: ./contrib/build-package.sh -j -v -i fastfloat
       - name: "Install dependency: folly"
         run: ./contrib/build-package.sh -j -v -i folly
       - name: "Install dependency: fizz"

--- a/.github/workflows/build-cachelib-rockylinux-9.yml
+++ b/.github/workflows/build-cachelib-rockylinux-9.yml
@@ -76,6 +76,8 @@ jobs:
         run: ./contrib/build-package.sh -j -v -i sparsemap
       - name: "Install dependency: fmt"
         run: ./contrib/build-package.sh -j -v -i fmt
+      - name: "Install dependency: fastfloat"
+        run: ./contrib/build-package.sh -j -v -i fastfloat
       - name: "Install dependency: folly"
         run: |
           # see: https://aur.archlinux.org/packages/folly#comment-862543

--- a/.github/workflows/build-cachelib-ubuntu-22.yml
+++ b/.github/workflows/build-cachelib-ubuntu-22.yml
@@ -74,6 +74,8 @@ jobs:
         run: ./contrib/build-package.sh -j -v -i sparsemap
       - name: "Install dependency: fmt"
         run: ./contrib/build-package.sh -j -v -i fmt
+      - name: "Install dependency: fastfloat"
+        run: ./contrib/build-package.sh -j -v -i fastfloat
       - name: "Install dependency: folly"
         run: ./contrib/build-package.sh -j -v -i folly
       - name: "Install dependency: fizz"

--- a/cachelib/allocator/CMakeLists.txt
+++ b/cachelib/allocator/CMakeLists.txt
@@ -27,7 +27,16 @@ add_library (cachelib_allocator
   ${SERIALIZE_THRIFT_FILES}
   ${DATASTRUCT_SERIALIZE_THRIFT_FILES}
   ${MEMORY_SERIALIZE_THRIFT_FILES}
-    CacheAllocator.cpp
+    CacheAllocatorLru2QCache.cpp
+    CacheAllocatorLru5B2QCache.cpp
+    CacheAllocatorLru5BCache.cpp
+    CacheAllocatorLru5BCacheWithSpinBuckets.cpp
+    CacheAllocatorLruCache.cpp
+    CacheAllocatorLruCacheWithSpinBuckets.cpp
+    CacheAllocatorTinyLFU5BCache.cpp
+    CacheAllocatorTinyLFUCache.cpp
+    CacheAllocatorWTinyLFU5BCache.cpp
+    CacheAllocatorWTinyLFUCache.cpp
     Cache.cpp
     CacheDetails.cpp
     CacheStats.cpp

--- a/cachelib/allocator/memory/CompressedPtr.h
+++ b/cachelib/allocator/memory/CompressedPtr.h
@@ -252,7 +252,7 @@ class CACHELIB_PACKED_ATTR CompressedPtr5B {
       : ptr_(compress(slabIdx, allocIdx, isMultiTiered, tid)),
         regionIdx_(getRegionIdx(slabIdx, isMultiTiered, tid)) {}
 
-  constexpr explicit CompressedPtr5B(PtrType ptr) noexcept
+  CompressedPtr5B(PtrType ptr) noexcept
       : ptr_(deserializePtr(ptr)), regionIdx_(deserializeRegion(ptr)) {}
 
   // number of bits for the Allocation offset in a slab.  With slab size of 22

--- a/cachelib/allocator/memory/tests/TestBase.h
+++ b/cachelib/allocator/memory/tests/TestBase.h
@@ -77,7 +77,7 @@ class AllocTestBase : public testing::Test {
   }
 
   template <typename CompressedPtrType>
-  CompressedPtrType::PtrType compress(CompressedPtrType ptr,
+  typename CompressedPtrType::PtrType compress(CompressedPtrType ptr,
                                       uint32_t slabIdx,
                                       uint32_t allocIdx,
                                       bool isMultiTiered) {

--- a/contrib/build-package.sh
+++ b/contrib/build-package.sh
@@ -59,7 +59,7 @@ options:
 NAME: the dependency to build supported values are:
   zstd
   googlelog, googleflags, googletest,
-  fmt, sparsemap,
+  fmt, sparsemap, fastfloat,
   folly, fizz, wangle, mvfst, fbthrift,
   cachelib
 
@@ -190,6 +190,14 @@ case "$1" in
   sparsemap)
     NAME=sparsemap
     REPO=https://github.com/Tessil/sparse-map.git
+    REPODIR=cachelib/external/$NAME
+    SRCDIR=$REPODIR
+    external_git_clone=yes
+    ;;
+
+  fastfloat)
+    NAME=fastfloat
+    REPO=https://github.com/fastfloat/fast_float.git
     REPODIR=cachelib/external/$NAME
     SRCDIR=$REPODIR
     external_git_clone=yes

--- a/contrib/build.sh
+++ b/contrib/build.sh
@@ -95,7 +95,7 @@ build_arch()
 
 build_dependencies()
 {
-  for pkg in zstd googleflags googlelog googletest sparsemap fmt folly fizz wangle mvfst fbthrift ;
+  for pkg in zstd googleflags googlelog googletest sparsemap fmt fastfloat folly fizz wangle mvfst fbthrift ;
   do
     # shellcheck disable=SC2086
     ./contrib/build-package.sh $pass_params "$pkg" \

--- a/contrib/prerequisites-centos9.sh
+++ b/contrib/prerequisites-centos9.sh
@@ -35,7 +35,7 @@ sudo dnf install -y \
   gtest-devel \
   libsodium-static \
   libdwarf-static \
-  xxhash \
+  xxhash-devel \
   numactl-devel
 
 

--- a/contrib/prerequisites-centos9.sh
+++ b/contrib/prerequisites-centos9.sh
@@ -35,6 +35,7 @@ sudo dnf install -y \
   gtest-devel \
   libsodium-static \
   libdwarf-static \
+  xxhash \
   numactl-devel
 
 

--- a/contrib/prerequisites-rocky9.sh
+++ b/contrib/prerequisites-rocky9.sh
@@ -39,6 +39,7 @@ sudo dnf install -y \
   libsodium-devel \
   libaio-devel \
   binutils-devel \
+  xxhash-devel \
   numactl-devel
 
 

--- a/contrib/prerequisites-ubuntu18.sh
+++ b/contrib/prerequisites-ubuntu18.sh
@@ -41,7 +41,7 @@ sudo apt-get install -y \
   libdwarf-dev \
   libsodium-dev \
   libaio-dev \
-  xxhash \
+  libxxhash-dev \
   libnuma-dev
 
 # NOTE:

--- a/contrib/prerequisites-ubuntu18.sh
+++ b/contrib/prerequisites-ubuntu18.sh
@@ -41,6 +41,7 @@ sudo apt-get install -y \
   libdwarf-dev \
   libsodium-dev \
   libaio-dev \
+  xxhash \
   libnuma-dev
 
 # NOTE:


### PR DESCRIPTION
This patch includes some of the changes in https://github.com/facebook/CacheLib/pull/349 to fix the compiling of the new .cpp files. 

It fixes some of the constexpr related errors.