### PR TITLE
Fix Variable Names for P100(Max) Latency in Cachebench

### DIFF
--- a/cachelib/cachebench/cache/Cache.h
+++ b/cachelib/cachebench/cache/Cache.h
@@ -1234,7 +1234,7 @@ Stats Cache<Allocator>::getStats() const {
         lookup("navy_device_read_latency_us_p99999");
     ret.nvmReadLatencyMicrosP999999 =
         lookup("navy_device_read_latency_us_p999999");
-    ret.nvmReadLatencyMicrosP100 = lookup("navy_device_read_latency_us_p100");
+    ret.nvmReadLatencyMicrosMax = lookup("navy_device_read_latency_us_max");
     ret.nvmWriteLatencyMicrosP50 = lookup("navy_device_write_latency_us_p50");
     ret.nvmWriteLatencyMicrosP90 = lookup("navy_device_write_latency_us_p90");
     ret.nvmWriteLatencyMicrosP99 = lookup("navy_device_write_latency_us_p99");
@@ -1245,7 +1245,7 @@ Stats Cache<Allocator>::getStats() const {
         lookup("navy_device_write_latency_us_p99999");
     ret.nvmWriteLatencyMicrosP999999 =
         lookup("navy_device_write_latency_us_p999999");
-    ret.nvmWriteLatencyMicrosP100 = lookup("navy_device_write_latency_us_p100");
+    ret.nvmWriteLatencyMicrosMax = lookup("navy_device_write_latency_us_max");
     ret.numNvmItemRemovedSetSize = lookup("items_tracked_for_destructor");
 
     // track any non-zero check sum errors or io errors

--- a/cachelib/cachebench/cache/CacheStats.h
+++ b/cachelib/cachebench/cache/CacheStats.h
@@ -97,7 +97,7 @@ struct Stats {
   double nvmReadLatencyMicrosP9999{0};
   double nvmReadLatencyMicrosP99999{0};
   double nvmReadLatencyMicrosP999999{0};
-  double nvmReadLatencyMicrosP100{0};
+  double nvmReadLatencyMicrosMax{0};
   double nvmWriteLatencyMicrosP50{0};
   double nvmWriteLatencyMicrosP90{0};
   double nvmWriteLatencyMicrosP99{0};
@@ -105,7 +105,7 @@ struct Stats {
   double nvmWriteLatencyMicrosP9999{0};
   double nvmWriteLatencyMicrosP99999{0};
   double nvmWriteLatencyMicrosP999999{0};
-  double nvmWriteLatencyMicrosP100{0};
+  double nvmWriteLatencyMicrosMax{0};
 
   uint64_t numNvmExceededMaxRetry{0};
 
@@ -317,7 +317,7 @@ struct Stats {
       fmtLatency(readCat, "p9999", nvmReadLatencyMicrosP9999);
       fmtLatency(readCat, "p99999", nvmReadLatencyMicrosP99999);
       fmtLatency(readCat, "p999999", nvmReadLatencyMicrosP999999);
-      fmtLatency(readCat, "p100", nvmReadLatencyMicrosP100);
+      fmtLatency(readCat, "max", nvmReadLatencyMicrosMax);
 
       fmtLatency(writeCat, "p50", nvmWriteLatencyMicrosP50);
       fmtLatency(writeCat, "p90", nvmWriteLatencyMicrosP90);
@@ -326,7 +326,7 @@ struct Stats {
       fmtLatency(writeCat, "p9999", nvmWriteLatencyMicrosP9999);
       fmtLatency(writeCat, "p99999", nvmWriteLatencyMicrosP99999);
       fmtLatency(writeCat, "p999999", nvmWriteLatencyMicrosP999999);
-      fmtLatency(writeCat, "p100", nvmWriteLatencyMicrosP100);
+      fmtLatency(writeCat, "max", nvmWriteLatencyMicrosMax);
 
       constexpr double GB = 1024.0 * 1024 * 1024;
       double appWriteAmp =


### PR DESCRIPTION
# Issue
```
== Test Results ==
== Allocator Stats ==
...
NVM Read  Latency    p999999  :     10000.00 us
NVM Read  Latency    p100      :    0.00 us
...
NVM Write Latency    p999999  :     10000.00 us
NVM Write Latency    p100      :     0.00 us
...
```

# Debug
Cachelib is using variable name for p100 as max (cachelib/common/PercentileStats.cpp:72). But, Cachebench was using variable name for p100 as p100. So, I have changed Cachebench's variable name to max.

# Result
```
== Test Results ==
== Allocator Stats ==
...
NVM Read  Latency    p999999  :     10000.00 us
NVM Read  Latency    max      :    20000.00 us
...
NVM Write Latency    p999999  :     10000.00 us
NVM Write Latency    max      :     20000.00 us
...
```