### PR TITLE
Fix CMake build related to index code refactor

### DIFF
--- a/cachelib/navy/CMakeLists.txt
+++ b/cachelib/navy/CMakeLists.txt
@@ -25,10 +25,10 @@ add_library (cachelib_navy
   block_cache/BlockCache.cpp
   block_cache/FifoPolicy.cpp
   block_cache/HitsReinsertionPolicy.cpp
-  block_cache/Index.cpp
   block_cache/LruPolicy.cpp
   block_cache/Region.cpp
   block_cache/RegionManager.cpp
+  block_cache/SparseMapIndex.cpp
   common/Buffer.cpp
   common/Device.cpp
   common/FdpNvme.cpp


### PR DESCRIPTION
In https://github.com/facebook/CacheLib/commit/d0139afcac157a0a3efa10dd833624da117ec5f0, `block_cache/Index.cpp` was renamed to `block_cache/SparseMapIndex.cpp`, but this change was not reflected in the cmake build, causing errors.