### PR TITLE
Some CMake improvements

### DIFF
--- a/build/fbcode_builder/getdeps/builder.py
+++ b/build/fbcode_builder/getdeps/builder.py
@@ -1381,7 +1381,7 @@ class SqliteBuilder(BuilderBase):
             copy_if_different(src, dest)
 
         cmake_lists = """
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5...4.0)
 project(sqlite3 C)
 add_library(sqlite3 STATIC sqlite3.c)
 # These options are taken from the defaults in Makefile.msc in

--- a/build/fbcode_builder/getdeps/py_wheel_builder.py
+++ b/build/fbcode_builder/getdeps/py_wheel_builder.py
@@ -21,7 +21,7 @@ WheelNameInfo = collections.namedtuple(
 )
 
 CMAKE_HEADER = """
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8...4.0)
 
 project("{manifest_name}" LANGUAGES C)
 

--- a/cachelib/CMakeLists.txt
+++ b/cachelib/CMakeLists.txt
@@ -44,16 +44,17 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(BUILD_TESTS "If enabled, compile the tests." ON)
 
+include(GNUInstallDirs)
 
-set(BIN_INSTALL_DIR bin CACHE STRING
+set(BIN_INSTALL_DIR ${CMAKE_INSTALL_BINDIR} CACHE STRING
     "The subdirectory where binaries should be installed")
 set(TESTS_INSTALL_DIR tests CACHE STRING
     "The subdirectory where test binaries should be installed")
-set(INCLUDE_INSTALL_DIR include/cachelib CACHE STRING
+set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR}/cachelib CACHE STRING
     "The subdirectory where header files should be installed")
-set(LIB_INSTALL_DIR lib CACHE STRING
+set(LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR} CACHE STRING
     "The subdirectory where libraries should be installed")
-set(CMAKE_INSTALL_DIR lib/cmake/cachelib CACHE STRING
+set(CMAKE_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/cachelib CACHE STRING
     "The subdirectory where CMake package config files should be installed")
 set(CONFIGS_INSTALL_DIR test_configs CACHE STRING
     "The subdirectory where sample test configurations should be installed")

--- a/cachelib/CMakeLists.txt
+++ b/cachelib/CMakeLists.txt
@@ -17,7 +17,7 @@
 # refer to the root source directory of the project as ${HELLO_SOURCE_DIR} and
 # to the root binary directory of the project as ${HELLO_BINARY_DIR}.
 
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.12...4.0)
 
 ## TODO: get version from variable
 project (CacheLib VERSION 0.1)

--- a/examples/simple_cache/CMakeLists.txt
+++ b/examples/simple_cache/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.12...4.0)
 
 project (cachelib-cmake-test-project VERSION 0.1)
 

--- a/examples/simple_compact_cache/CMakeLists.txt
+++ b/examples/simple_compact_cache/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.12...4.0)
 
 project (cachelib-cmake-test-project VERSION 0.1)
 

--- a/examples/single_tier_cache/CMakeLists.txt
+++ b/examples/single_tier_cache/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.12...4.0)
 
 project (cachelib-cmake-test-project VERSION 0.1)
 


### PR DESCRIPTION
- Bump the maximum CMake policy
- Use `GNUInstallDirs` as defaults to simplify donwstream's packaging

The first change could technically be problematic if an old policy is implicitly used, but these are generally unlikely. The motivation for that is to simplify downstream maintenance in the long run. CI builds should pick up any issues