### PR TITLE
Enable DSA acceleration using DTO library

### DIFF
--- a/build/fbcode_builder/manifests/accel-config
+++ b/build/fbcode_builder/manifests/accel-config
@@ -1,0 +1,9 @@
+[manifest]
+name = accel-config
+
+[rpms]
+accel-config-devel
+
+[debs.distro=ubuntu]
+libaccel-config-dev
+

--- a/build/fbcode_builder/manifests/cachelib
+++ b/build/fbcode_builder/manifests/cachelib
@@ -25,6 +25,7 @@ zstd
 mvfst
 numa
 libaio
+dto
 # cachelib also depends on openssl but since the latter requires a platform-
 # specific configuration we rely on the folly manifest to provide this
 # dependency to avoid duplication.

--- a/build/fbcode_builder/manifests/dto
+++ b/build/fbcode_builder/manifests/dto
@@ -1,0 +1,14 @@
+[manifest]
+name = dto
+
+[git]
+repo_url = https://github.com/intel/DTO.git
+branch = cachelib
+
+[build]
+builder = cmake
+
+[dependencies]
+accel-config
+uuid
+numa

--- a/build/fbcode_builder/manifests/uuid
+++ b/build/fbcode_builder/manifests/uuid
@@ -1,0 +1,9 @@
+[manifest]
+name = uuid
+
+[rpms]
+libuuid-devel
+
+[debs]
+uuid-dev
+

--- a/cachelib/CMakeLists.txt
+++ b/cachelib/CMakeLists.txt
@@ -44,6 +44,16 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(BUILD_TESTS "If enabled, compile the tests." ON)
 
+option(BUILD_WITH_DTO "If enabled, build with the DTO library for DSA support." OFF)
+
+if (BUILD_WITH_DTO)
+    find_package(DTO REQUIRED)
+    if (DTO_FOUND)
+        message(STATUS "DTO found, remember to configure DSA devices for acceleration. If no DSA device is found, cachelib will fallback to software path.")
+        add_compile_definitions(HAVE_DTO)
+    endif()
+endif ()
+
 
 set(BIN_INSTALL_DIR bin CACHE STRING
     "The subdirectory where binaries should be installed")

--- a/cachelib/cachebench/CMakeLists.txt
+++ b/cachelib/cachebench/CMakeLists.txt
@@ -67,11 +67,14 @@ else()
   target_compile_definitions(cachelib_cachebench PRIVATE SKIP_OPTION_SIZE_VERIFY)
 endif()
 
-
 add_executable (cachebench main.cpp)
 add_executable (binary_trace_gen binary_trace_gen.cpp)
 target_link_libraries(cachebench cachelib_cachebench)
 target_link_libraries(binary_trace_gen cachelib_binary_trace_gen)
+
+if (BUILD_WITH_DTO)
+    target_link_libraries(cachebench accel-config DTO::dto)
+endif()
 
 install(
   TARGETS

--- a/cachelib/cachebench/CMakeLists.txt
+++ b/cachelib/cachebench/CMakeLists.txt
@@ -67,6 +67,7 @@ else()
   target_compile_definitions(cachelib_cachebench PRIVATE SKIP_OPTION_SIZE_VERIFY)
 endif()
 
+
 add_executable (cachebench main.cpp)
 add_executable (binary_trace_gen binary_trace_gen.cpp)
 target_link_libraries(cachebench cachelib_cachebench)

--- a/cachelib/cachebench/cache/Cache.h
+++ b/cachelib/cachebench/cache/Cache.h
@@ -1331,7 +1331,7 @@ void Cache<Allocator>::setStringItem(WriteHandle& handle,
   }
 
   auto ptr = reinterpret_cast<char*>(getMemory(handle));
-  std::strncpy(ptr, str.c_str(), dataSize);
+  std::memmove(ptr, str.c_str(), dataSize);
 
   // Make sure the copied string ends with null char
   if (str.size() + 1 > dataSize) {

--- a/cachelib/cachebench/runner/CacheStressor.h
+++ b/cachelib/cachebench/runner/CacheStressor.h
@@ -48,10 +48,12 @@ namespace cachebench {
 
 constexpr uint32_t kNvmCacheWarmUpCheckRate = 1000;
 
+#ifdef HAVE_DTO
 void async_memcpy_callback(void *arg) {
     auto &fn = *reinterpret_cast<std::function<void(void)>*>(arg);
     fn();
 }
+#endif
 
 // Implementation of stressor that uses a workload generator to stress an
 // instance of the cache.  All item's value in CacheStressor follows CacheValue

--- a/cachelib/cachebench/util/Config.cpp
+++ b/cachelib/cachebench/util/Config.cpp
@@ -68,6 +68,7 @@ StressorConfig::StressorConfig(const folly::dynamic& configJson) {
   JSONSetVal(configJson, checkNvmCacheWarmUp);
 
   JSONSetVal(configJson, useCombinedLockForIterators);
+  JSONSetVal(configJson, useDTOAsync);
 
   if (configJson.count("poolDistributions")) {
     for (auto& it : configJson["poolDistributions"]) {

--- a/cachelib/cachebench/util/Config.h
+++ b/cachelib/cachebench/util/Config.h
@@ -331,7 +331,7 @@ struct StressorConfig : public JSONConfig {
   uint64_t timestampFactor{1000};
 
   bool useCombinedLockForIterators{false};
-  
+
   // if we want to use async DSA function
   bool useDTOAsync{false};
 

--- a/cachelib/cachebench/util/Config.h
+++ b/cachelib/cachebench/util/Config.h
@@ -331,6 +331,9 @@ struct StressorConfig : public JSONConfig {
   uint64_t timestampFactor{1000};
 
   bool useCombinedLockForIterators{false};
+  
+  // if we want to use async DSA function
+  bool useDTOAsync{false};
 
   // admission policy for cache.
   std::shared_ptr<StressorAdmPolicy> admPolicy{};

--- a/cachelib/navy/CMakeLists.txt
+++ b/cachelib/navy/CMakeLists.txt
@@ -69,7 +69,6 @@ install(TARGETS cachelib_navy
         EXPORT cachelib-exports
         DESTINATION ${LIB_INSTALL_DIR} )
 
-
 if (BUILD_TESTS)
   add_library(navy_test_support
     testing/BufferGen.cpp

--- a/cachelib/navy/CMakeLists.txt
+++ b/cachelib/navy/CMakeLists.txt
@@ -61,9 +61,14 @@ target_link_libraries(cachelib_navy PUBLIC
   GTest::gmock
   )
 
+if (BUILD_WITH_DTO)
+    target_link_libraries(cachelib_navy PUBLIC DTO::dto)
+endif()
+
 install(TARGETS cachelib_navy
         EXPORT cachelib-exports
         DESTINATION ${LIB_INSTALL_DIR} )
+
 
 if (BUILD_TESTS)
   add_library(navy_test_support

--- a/cachelib/navy/block_cache/BlockCache.cpp
+++ b/cachelib/navy/block_cache/BlockCache.cpp
@@ -35,10 +35,13 @@
 
 namespace facebook::cachelib::navy {
 
+#ifdef HAVE_DTO
 void async_memcpy_crc_cb(void *arg) {
     auto &fn = *reinterpret_cast<std::function<void(void)>*>(arg);
     fn();
 }
+#endif
+
 
 BlockCache::Config& BlockCache::Config::validate() {
   XDCHECK_NE(scheduler, nullptr);

--- a/cachelib/navy/common/Hash.cpp
+++ b/cachelib/navy/common/Hash.cpp
@@ -17,6 +17,9 @@
 #include "cachelib/navy/common/Hash.h"
 
 #include <folly/hash/Checksum.h>
+#ifdef HAVE_DTO
+#include <dto.h>
+#endif
 
 namespace facebook::cachelib::navy {
 uint64_t hashBuffer(BufferView key, uint64_t seed) {
@@ -24,6 +27,10 @@ uint64_t hashBuffer(BufferView key, uint64_t seed) {
 }
 
 uint32_t checksum(BufferView data, uint32_t startingChecksum) {
+#ifdef HAVE_DTO
+  return dto_crc(data.data(), data.size(), nullptr, nullptr);
+#else
   return folly::crc32(data.data(), data.size(), startingChecksum);
+#endif
 }
 } // namespace facebook::cachelib::navy

--- a/cachelib/navy/common/Hash.h
+++ b/cachelib/navy/common/Hash.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <cstdint>
-
 #include "cachelib/common/Hash.h"
 #include "cachelib/navy/common/Buffer.h"
 

--- a/cachelib/navy/common/Hash.h
+++ b/cachelib/navy/common/Hash.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstdint>
+
 #include "cachelib/common/Hash.h"
 #include "cachelib/navy/common/Buffer.h"
 


### PR DESCRIPTION
This PR adds support for the DTO library which enables the DSA accelerator. In our experiments using the CDN traces and relevant configs - we have measured up to 40% improvement in throughput.

<img width="577" height="452" alt="image" src="https://github.com/user-attachments/assets/8186c576-4413-4c2b-b088-1dbb299aa1b5" />

We also include support for CRC offloading via the DTO API (please note the DTO API is currently under development). 

To use DSA with CacheLib, do the following:

## Linux Kernel Configuration
Ensure the following kernel options are enabled:
```plaintext
CONFIG_INTEL_IOMMU=y
CONFIG_INTEL_IOMMU_SVM=y
CONFIG_INTEL_IOMMU_DEFAULT_ON=y
CONFIG_INTEL_IOMMU_SCALABLE_MODE_DEFAULT_ON=y
```
If either `CONFIG_INTEL_IOMMU_DEFAULT_ON` or `CONFIG_INTEL_IOMMU_SCALABLE_MODE_DEFAULT_ON` is not enabled, add the following to the kernel boot parameters:
```plaintext
intel_iommu=on,sm_on
```

### Intel DSA Driver (IDXD)
Enable the following kernel options while building or installing the Linux kernel (version 5.18 or later is needed for shared work queues used by DTO):
```plaintext
CONFIG_INTEL_IDXD=m
CONFIG_INTEL_IDXD_SVM=y
CONFIG_INTEL_IDXD_PERFMON=y
```

## Initialize the DSA Device

Navigate to where CacheLib downloaded the DTO library (cachelib branch, see https://github.com/intel/DTO) and run:
```sh
sudo ./accelConfig.sh 0 yes 0 
```
This enables dsa0 device, you can repeat for dsa2, dsa4, ..., depending on the number of devices on your platform.

### DSA Device Permissions
To allow userpace applications to submit work to the DSA, you need to give the appropriate permissions, 
for example to give all users the ability to submit work to device 0 work queue:
```sh
sudo chmod 0777 /dev/dsa/wq0.0
```
Of course, regular Unix permissions can be used to control access to the device.

### Accel config
You can also setup the device using the accel-config tool with a configuration file:
```sh
sudo accel-config -c <config_file>
```

## Using with CacheLib

To connect to CacheLib (OSS version) using the DTO library, you will need to ensure that your application is linked against the `libdto` library. We do this automatically via the `./getdeps.py` script, but you can also build and install out of CacheLib.

### Linking to CacheLib without using the fbcode_builder

Cachebench needs a change for setStringItem to use 'std::memmove' instead of 'strncpy' as DTO does not intercept strncpy call. The patch also adds the build option for DTO in cmake.

```sh
cd ~/CacheLib/
git apply ~/DTO/cachelib.patch
cd build-cachelib/
cmake ../cachelib \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
  -DBUILD_WITH_DTO=ON
make -j$(nproc)
make install
```
### Example Usage For Complete Offload

You can set the following environment variables to use the DTO library with CacheLib:

```plaintext
DTO_USESTDC_CALLS=0 // Set to 1 to use standard C library calls (like memcpy) instead of DSA enabled calls
DTO_COLLECT_STATS=0 // Set to 1 to collect stats on DSA performance
DTO_WAIT_METHOD=sleep // sleep, umwait, tpause, yield, or busypoll after submitting to DSA
DTO_MIN_BYTES=32768 // Minimum bytes for DSA to process, smaller requests will be done on CPU to avoid latency increase
DTO_CPU_SIZE_FRACTION=0.0 //offload the entire call to DSA
DTO_AUTO_ADJUST_KNOBS=0 //Tries to find the optimal split between CPU fraction and DSA fraction, attempting to minimize the difference in time between the two
DTO_DSA_CC=0 // Set to 0 to bypass CPU cache for the destination buffer, this will ensure that the data is written from DSA directly to memory avoidng polluting the cache with a large buffer that has low probablity of being reaccessed.
```

```sh
source ~/DTO/dto_cachelib_env.sh
./opt/cachelib/bin/cachebench --json_test_config ~/DTO/cachebench_config.json
```

### Example Usage For Partial Offload

Set the following enviroment variables to use the DTO library with CacheLib:
```plaintext
DTO_USESTDC_CALLS=0 // Set to 1 to use standard C library calls (like memcpy) instead of DSA enabled calls
DTO_COLLECT_STATS=0 // Set to 1 to collect stats on DSA performance
DTO_WAIT_METHOD=tpause // or umait
DTO_MIN_BYTES=32768 // Minimum bytes for DSA to process, smaller requests will be done on CPU
DTO_CPU_SIZE_FRACTION=0.0 //offload the entire call to DSA
DTO_AUTO_ADJUST_KNOBS=2 //Tries to find the optimal split between CPU fraction and DSA fraction, attempting to minimize the difference in time between the two
DTO_DSA_CC=0 // Set to 0 to bypass CPU cache for the destination buffer, this will ensure that the data is written from DSA directly to memory avoidng polluting the cache with a large buffer that has low probablity of being reaccessed.
```
```sh
./opt/cachelib/bin/cachebench --json_test_config ~/DTO/cachebench_config.json
```

## A note on the wait methods

The wait method is used to wait for the DSA to complete the operation. The following methods are supported:
- **sleep**: The thread will sleep for a fixed amount of time.
- **umwait**: The thread will use the umwait instruction to wait for the DSA to complete the operation. Umwait
monitors the address of the DSA descriptor and waits for the DSA to complete the operation.
- **tpause**: The thread will use the tpause instruction to wait for the DSA to complete the operation.
- **yield**: The thread will yield the CPU to the OS.
- **busypoll**: The thread will busy poll the DSA to check if the operation is complete. It uses the 
regular mm_pause instruction to send noops to the core while waiting.

Both umwait and tpause are recommended as they are more efficient than sleep and yield since they do not
cause a context switch. In addition, umwait and tpause are more efficient than busypoll as the allow
the CPU to enter C0.1 or C0.2 states which are low power states, C0.2 has ~0.5us exit latency while C0.1
has ~0.25us exit latency. Therefore, C0.1 is used when autotuning is enabled to do a portion of the work
on the CPU and the remainder on the core as our goal is to minimize the time gap between the two. If we 
are doing a complete offload we enter C0.2.


### Additional References
- [Data Streaming Accelerator User Guide](https://www.intel.com/content/www/us/en/content-details/759709/intel-data-streaming-accelerator-user-guide.html)
- [Data Streaming Accelerator Architecture Specification](https://cdrdv2-public.intel.com/671116/341204-intel-data-streaming-accelerator-spec.pdf)


