### PR TITLE
Add S3FIFO Eviction Algorithm

### DIFF
--- a/cachelib/allocator/CMakeLists.txt
+++ b/cachelib/allocator/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library (cachelib_allocator
     CacheAllocatorLru5BCacheWithSpinBuckets.cpp
     CacheAllocatorLruCache.cpp
     CacheAllocatorLruCacheWithSpinBuckets.cpp
+    CacheAllocatorS3FIFOCache.cpp
     CacheAllocatorTinyLFU5BCache.cpp
     CacheAllocatorTinyLFUCache.cpp
     CacheAllocatorWTinyLFU5BCache.cpp

--- a/cachelib/allocator/CMakeLists.txt
+++ b/cachelib/allocator/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library (cachelib_allocator
     CacheAllocatorLruCache.cpp
     CacheAllocatorLruCacheWithSpinBuckets.cpp
     CacheAllocatorS3FIFOCache.cpp
+    CacheAllocatorS3FIFO5BCache.cpp
     CacheAllocatorTinyLFU5BCache.cpp
     CacheAllocatorTinyLFUCache.cpp
     CacheAllocatorWTinyLFU5BCache.cpp

--- a/cachelib/allocator/CacheAllocator.h
+++ b/cachelib/allocator/CacheAllocator.h
@@ -6077,6 +6077,7 @@ namespace facebook::cachelib {
 extern template class CacheAllocator<LruCacheTrait>;
 extern template class CacheAllocator<LruCacheWithSpinBucketsTrait>;
 extern template class CacheAllocator<Lru2QCacheTrait>;
+extern template class CacheAllocator<S3FIFOCacheTrait>;
 extern template class CacheAllocator<TinyLFUCacheTrait>;
 extern template class CacheAllocator<WTinyLFUCacheTrait>;
 
@@ -6097,6 +6098,14 @@ using LruAllocatorSpinBuckets = CacheAllocator<LruCacheWithSpinBucketsTrait>;
 //  3. items in cold queue are evicted to make room for new items
 using Lru2QAllocator = CacheAllocator<Lru2QCacheTrait>;
 using Lru5B2QAllocator = CacheAllocator<Lru5B2QCacheTrait>;
+
+// CacheAllocator with S3 FIFO eviction policy
+// It maintains 2 queues, one for for probation and one for the main queue.
+// New items are added to the probation queue, and if not accessed
+// will be quickly removed from the cache to remove 1 hit wonders.
+// If accessed while in probation, it will eventually be promoted to the main queue.
+// Items in the tail of main queue will be reinserted if accessed.
+using S3FIFOAllocator = CacheAllocator<S3FIFOCacheTrait>;
 
 // CacheAllocator with Tiny LFU eviction policy
 // It has a window initially to gauage the frequency of accesses of newly

--- a/cachelib/allocator/CacheAllocator.h
+++ b/cachelib/allocator/CacheAllocator.h
@@ -6106,6 +6106,7 @@ using Lru5B2QAllocator = CacheAllocator<Lru5B2QCacheTrait>;
 // If accessed while in probation, it will eventually be promoted to the main queue.
 // Items in the tail of main queue will be reinserted if accessed.
 using S3FIFOAllocator = CacheAllocator<S3FIFOCacheTrait>;
+using S3FIFO5BAllocator = CacheAllocator<S3FIFO5BCacheTrait>;
 
 // CacheAllocator with Tiny LFU eviction policy
 // It has a window initially to gauage the frequency of accesses of newly

--- a/cachelib/allocator/CacheAllocatorS3FIFO5BCache.cpp
+++ b/cachelib/allocator/CacheAllocatorS3FIFO5BCache.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cachelib/allocator/CacheAllocator.h"
+
+namespace facebook::cachelib {
+template class CacheAllocator<S3FIFO5BCacheTrait>;
+}

--- a/cachelib/allocator/CacheAllocatorS3FIFOCache.cpp
+++ b/cachelib/allocator/CacheAllocatorS3FIFOCache.cpp
@@ -14,21 +14,8 @@
  * limitations under the License.
  */
 
-#include "cachelib/allocator/ChainedHashTable.h"
-#include "cachelib/allocator/MM2Q.h"
-#include "cachelib/allocator/MMLru.h"
-#include "cachelib/allocator/MMS3FIFO.h"
-#include "cachelib/allocator/MMTinyLFU.h"
-#include "cachelib/allocator/MMWTinyLFU.h"
-namespace facebook::cachelib {
-// Types of AccessContainer and MMContainer
-// MMType
-const int MMLru::kId = 1;
-const int MM2Q::kId = 2;
-const int MMTinyLFU::kId = 3;
-const int MMWTinyLFU::kId = 4;
-const int MMS3FIFO::kId = 5;
+#include "cachelib/allocator/CacheAllocator.h"
 
-// AccessType
-const int ChainedHashTable::kId = 1;
-} // namespace facebook::cachelib
+namespace facebook::cachelib {
+template class CacheAllocator<S3FIFOCacheTrait>;
+}

--- a/cachelib/allocator/CacheTraits.h
+++ b/cachelib/allocator/CacheTraits.h
@@ -18,6 +18,7 @@
 #include "cachelib/allocator/ChainedHashTable.h"
 #include "cachelib/allocator/MM2Q.h"
 #include "cachelib/allocator/MMLru.h"
+#include "cachelib/allocator/MMS3FIFO.h"
 #include "cachelib/allocator/MMTinyLFU.h"
 #include "cachelib/allocator/MMWTinyLFU.h"
 #include "cachelib/allocator/memory/CompressedPtr.h"
@@ -49,6 +50,13 @@ struct LruCacheWithSpinBucketsTrait {
 
 struct Lru2QCacheTrait {
   using MMType = MM2Q;
+  using AccessType = ChainedHashTable;
+  using AccessTypeLocks = SharedMutexBuckets;
+  using CompressedPtrType = CompressedPtr4B;
+};
+
+struct S3FIFOCacheTrait {
+  using MMType = MMS3FIFO;
   using AccessType = ChainedHashTable;
   using AccessTypeLocks = SharedMutexBuckets;
   using CompressedPtrType = CompressedPtr4B;

--- a/cachelib/allocator/CacheTraits.h
+++ b/cachelib/allocator/CacheTraits.h
@@ -97,6 +97,13 @@ struct Lru5B2QCacheTrait {
   using CompressedPtrType = CompressedPtr5B;
 };
 
+struct S3FIFO5BCacheTrait {
+  using MMType = MMS3FIFO;
+  using AccessType = ChainedHashTable;
+  using AccessTypeLocks = SharedMutexBuckets;
+  using CompressedPtrType = CompressedPtr5B;
+};
+
 struct TinyLFU5BCacheTrait {
   using MMType = MMTinyLFU;
   using AccessType = ChainedHashTable;

--- a/cachelib/allocator/MMS3FIFO.h
+++ b/cachelib/allocator/MMS3FIFO.h
@@ -468,7 +468,7 @@ void MMS3FIFO::Container<T, HookPtr>::maybeResizeGhostLocked() noexcept {
 
   size_t expectedGhostSize =
       static_cast<size_t>(lruSize * config_.ghostSizePercent / 100);
-  // ghostQueue_.resize(expectedGhostSize);
+  ghostQueue_.resize(expectedGhostSize);
   capacity_ = lruSize;
 }
 
@@ -539,8 +539,7 @@ bool MMS3FIFO::Container<T, HookPtr>::add(T& node) noexcept {
   const auto currTime = static_cast<Time>(util::getCurrentTimeSec());
 
   const auto nodeHash = hashNode(node);
-  // auto ghostContains = ghostQueue_.contains(nodeHash);
-  auto ghostContains = false;
+  auto ghostContains = ghostQueue_.contains(nodeHash);
   return lruMutex_->lock_combine([this, &node, currTime, ghostContains]() {
     if (node.isInMMContainer()) {
       return false;
@@ -680,7 +679,7 @@ bool MMS3FIFO::Container<T, HookPtr>::remove(T& node) noexcept {
   });
   if (result && isTiny_) {
     // // Insert to ghost queue
-    // ghostQueue_.insert(hashNode(node));
+    ghostQueue_.insert(hashNode(node));
   }
   return result;
 }
@@ -712,7 +711,7 @@ void MMS3FIFO::Container<T, HookPtr>::remove(LockedIterator& it) noexcept {
     if (it.l_.owns_lock()) {
       it.l_.unlock();
     }
-    // ghostQueue_.insert(hashNode(node));
+    ghostQueue_.insert(hashNode(node));
   }
   return;
 }

--- a/cachelib/allocator/MMS3FIFO_v-1.h
+++ b/cachelib/allocator/MMS3FIFO_v-1.h
@@ -1,0 +1,620 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#include <folly/Format.h>
+#include <folly/Math.h>
+#pragma GCC diagnostic pop
+
+#include "cachelib/allocator/Cache.h"
+#include "cachelib/allocator/CacheStats.h"
+#include "cachelib/allocator/Util.h"
+#include "cachelib/allocator/datastruct/MultiDList.h"
+#include "cachelib/allocator/memory/serialize/gen-cpp2/objects_types.h"
+#include "cachelib/common/CompilerUtils.h"
+#include "cachelib/common/Mutex.h"
+
+namespace facebook::cachelib {
+// MMS3FIFOV0
+// This version:
+// straight up takes tinyLFU's recordaccess function
+// eviction iterator always evicts from main
+// returns eviction age stats
+class MMS3FIFO {
+ public:
+  // unique identifier per MMType
+  static const int kId;
+
+  // forward declaration;
+  template <typename T>
+  using Hook = DListHook<T>;
+  using SerializationType = serialization::MMS3FIFOObject;
+  using SerializationConfigType = serialization::MMS3FIFOConfig;
+  using SerializationTypeContainer = serialization::MMS3FIFOCollection;
+
+  enum LruType { Main, Tiny, NumTypes };
+
+  // Config class for MMS3FIFO
+  struct Config {
+    // create from serialized config
+    explicit Config(SerializationConfigType configState)
+        : Config(*configState.updateOnWrite(),
+                 *configState.updateOnRead(),
+                 *configState.tinySizePercent(),
+                 *configState.ghostSizePercent()) {}
+
+    // @param udpateOnW   whether to promote the item on write
+    // @param updateOnR   whether to promote the item on read
+    Config(bool updateOnW, bool updateOnR)
+        : Config(updateOnW, updateOnR, 10, 90) {}
+
+    // @param udpateOnW         whether to promote the item on write
+    // @param updateOnR         whether to promote the item on read
+    // @param tinySizePercent   percentage number of tiny size to overall size
+    // @param ghostSizePercent  percentage number of ghost size to main size
+    Config(bool updateOnW,
+           bool updateOnR,
+           size_t tinySizePercent,
+           size_t ghostSizePercent)
+        : updateOnWrite(updateOnW),
+          updateOnRead(updateOnR),
+          tinySizePercent(tinySizePercent),
+          ghostSizePercent(ghostSizePercent) {}
+
+    Config() = default;
+    Config(const Config& rhs) = default;
+    Config(Config&& rhs) = default;
+
+    Config& operator=(const Config& rhs) = default;
+    Config& operator=(Config&& rhs) = default;
+
+    template <typename... Args>
+    void addExtraConfig(Args...) {}
+
+    // whether the lru needs to be updated on writes for recordAccess. If
+    // false, accessing the cache for writes does not promote the cached item
+    // to the head of the lru.
+    bool updateOnWrite{false};
+
+    // whether the lru needs to be updated on reads for recordAccess. If
+    // false, accessing the cache for reads does not promote the cached item
+    // to the head of the lru.
+    bool updateOnRead{true};
+
+    // The size of tiny cache, as a percentage of the total size.
+    size_t tinySizePercent{10};
+
+    size_t ghostSizePercent{90};
+  };
+
+  // The container object which can be used to keep track of objects of type
+  // T. T must have a public member of type Hook. This object is wrapper
+  // around DList, is thread safe and can be accessed from multiple threads.
+  // The current implementation models an LRU using the above DList
+  // implementation.
+  template <typename T, Hook<T> T::* HookPtr>
+  struct Container {
+   private:
+    using LruList = MultiDList<T, HookPtr>;
+    using Mutex = folly::SpinLock;
+    using LockHolder = std::unique_lock<Mutex>;
+    using PtrCompressor = typename T::PtrCompressor;
+    using Time = typename Hook<T>::Time;
+    using CompressedPtrType = typename T::CompressedPtrType;
+    using RefFlags = typename T::Flags;
+
+   public:
+    Container() = default;
+    Container(Config c, PtrCompressor compressor)
+        : lru_(LruType::NumTypes, std::move(compressor)),
+          config_(std::move(c)) {}
+    Container(serialization::MMS3FIFOObject object, PtrCompressor compressor);
+
+    Container(const Container&) = delete;
+    Container& operator=(const Container&) = delete;
+
+    // records the information that the node was accessed. This could bump up
+    // the node to the head of the lru depending on the time when the node was
+    // last updated in lru and the kLruRefreshTime. If the node was moved to
+    // the head in the lru, the node's updateTime will be updated
+    // accordingly.
+    //
+    // @param node  node that we want to mark as relevant/accessed
+    // @param mode  the mode for the access operation.
+    //
+    // @return      True if the information is recorded and bumped the node
+    //              to the head of the lru, returns false otherwise
+    bool recordAccess(T& node, AccessMode mode) noexcept;
+
+    // adds the given node into the container and marks it as being present in
+    // the container. The node is added to the head of the lru.
+    //
+    // @param node  The node to be added to the container.
+    // @return  True if the node was successfully added to the container. False
+    //          if the node was already in the contianer. On error state of node
+    //          is unchanged.
+    bool add(T& node) noexcept;
+
+    // removes the node from the lru and sets it previous and next to nullptr.
+    //
+    // @param node  The node to be removed from the container.
+    // @return  True if the node was successfully removed from the container.
+    //          False if the node was not part of the container. On error, the
+    //          state of node is unchanged.
+    bool remove(T& node) noexcept;
+
+    class LockedIterator;
+    // same as the above but uses an iterator context. The iterator is updated
+    // on removal of the corresponding node to point to the next node. The
+    // iterator context holds the lock on the lru.
+    //
+    // iterator will be advanced to the next node after removing the node
+    //
+    // @param it    Iterator that will be removed
+    void remove(LockedIterator& it) noexcept;
+
+    // replaces one node with another, at the same position
+    //
+    // @param oldNode   node being replaced
+    // @param newNode   node to replace oldNode with
+    //
+    // @return true  If the replace was successful. Returns false if the
+    //               destination node did not exist in the container, or if the
+    //               source node already existed.
+    bool replace(T& oldNode, T& newNode) noexcept;
+
+    // context for iterating the MM container. At any given point of time,
+    // there can be only one iterator active since we need to lock the LRU for
+    // iteration. we can support multiple iterators at same time, by using a
+    // shared ptr in the context for the lock holder in the future.
+    class LockedIterator {
+     public:
+      using ListIterator = typename LruList::DListIterator;
+      // noncopyable but movable.
+      LockedIterator(const LockedIterator&) = delete;
+      LockedIterator& operator=(const LockedIterator&) = delete;
+      LockedIterator(LockedIterator&&) noexcept = default;
+
+      LockedIterator& operator++() noexcept {
+        ++getIter();
+        return *this;
+      }
+
+      LockedIterator& operator--() {
+        throw std::invalid_argument(
+            "Decrementing eviction iterator is not supported");
+      }
+
+      T* operator->() const noexcept { return getIter().operator->(); }
+      T& operator*() const noexcept { return getIter().operator*(); }
+
+      bool operator==(const LockedIterator& other) const noexcept {
+        return &c_ == &other.c_ && tIter_ == other.tIter_ &&
+               mIter_ == other.mIter_;
+      }
+
+      bool operator!=(const LockedIterator& other) const noexcept {
+        return !(*this == other);
+      }
+
+      explicit operator bool() const noexcept { return tIter_ || mIter_; }
+
+      T* get() const noexcept { return getIter().get(); }
+
+      // Invalidates this iterator
+      void reset() noexcept {
+        // Point iterator to first list's rend
+        tIter_.reset();
+        mIter_.reset();
+      }
+
+      // 1. Invalidate this iterator
+      // 2. Unlock
+      void destroy() {
+        reset();
+        if (l_.owns_lock()) {
+          l_.unlock();
+        }
+      }
+
+      // Reset this iterator to the beginning
+      void resetToBegin() {
+        if (!l_.owns_lock()) {
+          l_.lock();
+        }
+        tIter_.resetToBegin();
+        mIter_.resetToBegin();
+      }
+
+     private:
+      // private because it's easy to misuse and cause deadlock for MMS3FIFO
+      LockedIterator& operator=(LockedIterator&&) noexcept = default;
+
+      // create an lru iterator with the lock being held.
+      explicit LockedIterator(LockHolder l,
+                              const Container<T, HookPtr>& c) noexcept;
+
+      const ListIterator& getIter() const noexcept {
+        return evictTiny() ? tIter_ : mIter_;
+      }
+
+      ListIterator& getIter() noexcept {
+        return const_cast<ListIterator&>(
+            static_cast<const LockedIterator*>(this)->getIter());
+      }
+
+      bool evictTiny() const noexcept {
+        if (!mIter_) {
+          return true;
+        }
+        if (!tIter_) {
+          return false;
+        }
+        // Simplification, evict from main first
+        return false;
+      }
+
+      // only the container can create iterators
+      friend Container<T, HookPtr>;
+
+      const Container<T, HookPtr>& c_;
+      // Tiny and main cache iterators
+      ListIterator tIter_;
+      ListIterator mIter_;
+      // lock protecting the validity of the iterator
+      LockHolder l_;
+    };
+
+    Config getConfig() const;
+
+    void setConfig(const Config& newConfig);
+
+    bool isEmpty() const noexcept {
+      LockHolder l(lruMutex_);
+      return lru_.size() == 0;
+    }
+
+    size_t size() const noexcept {
+      LockHolder l(lruMutex_);
+      return lru_.size();
+    }
+
+    // Returns the eviction age stats. See CacheStats.h for details
+    EvictionAgeStat getEvictionAgeStat(uint64_t projectedLength) const noexcept;
+
+    // Obtain an iterator that start from the tail and can be used
+    // to search for evictions. This iterator holds a lock to this
+    // container and only one such iterator can exist at a time
+    LockedIterator getEvictionIterator() const noexcept;
+
+    // Execute provided function under container lock. Function gets
+    // iterator passed as parameter.
+    template <typename F>
+    void withEvictionIterator(F&& f);
+
+    // Execute provided function under container lock.
+    template <typename F>
+    void withContainerLock(F&& f);
+
+    // for saving the state of the lru
+    //
+    // precondition:  serialization must happen without any reader or writer
+    // present. Any modification of this object afterwards will result in an
+    // invalid, inconsistent state for the serialized data.
+    //
+    serialization::MMS3FIFOObject saveState() const noexcept;
+
+    // return the stats for this container.
+    MMContainerStat getStats() const noexcept;
+
+    static LruType getLruType(const T& node) noexcept {
+      return isTiny(node) ? LruType::Tiny : LruType::Main;
+    }
+
+   private:
+    EvictionAgeStat getEvictionAgeStatLocked(
+        uint64_t projectedLength) const noexcept;
+
+    static Time getUpdateTime(const T& node) noexcept {
+      return (node.*HookPtr).getUpdateTime();
+    }
+
+    static void setUpdateTime(T& node, Time time) noexcept {
+      (node.*HookPtr).setUpdateTime(time);
+    }
+
+    // Returns the hash of node's key
+    static size_t hashNode(const T& node) noexcept {
+      return folly::hasher<folly::StringPiece>()(node.getKey());
+    }
+
+    // remove node from lru and adjust insertion points
+    //
+    // @param node          node to remove
+    void removeLocked(T& node) noexcept;
+
+    static bool isTiny(const T& node) noexcept {
+      return node.template isFlagSet<RefFlags::kMMFlag0>();
+    }
+
+    static bool isAccessed(const T& node) noexcept {
+      return node.template isFlagSet<RefFlags::kMMFlag1>();
+    }
+
+    // Bit MM_BIT_0 is used to record if the item is in tiny cache.
+    static void markTiny(T& node) noexcept {
+      node.template setFlag<RefFlags::kMMFlag0>();
+    }
+    static void unmarkTiny(T& node) noexcept {
+      node.template unSetFlag<RefFlags::kMMFlag0>();
+    }
+
+    // Bit MM_BIT_1 is used to record if the item has been accessed since being
+    // written in cache. Unaccessed items are ignored when determining projected
+    // update time.
+    static void markAccessed(T& node) noexcept {
+      node.template setFlag<RefFlags::kMMFlag1>();
+    }
+    static void unmarkAccessed(T& node) noexcept {
+      node.template unSetFlag<RefFlags::kMMFlag1>();
+    }
+
+    mutable Mutex lruMutex_;
+
+    // the lru
+    LruList lru_;
+
+    // Current capacity to track ghost size
+    size_t capacity_{0};
+
+    // Config for this lru.
+    // Write access to the MMS3FIFO Config is serialized.
+    // Reads may be racy.
+    Config config_{};
+
+    // FRIEND_TEST(MMTinyLFUTest, SegmentStress);
+    // FRIEND_TEST(MMTinyLFUTest, TinyLFUBasic);
+    // FRIEND_TEST(MMTinyLFUTest, Reconfigure);
+  };
+};
+
+/* Container Interface Implementation */
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+MMS3FIFO::Container<T, HookPtr>::Container(serialization::MMS3FIFOObject object,
+                                           PtrCompressor compressor)
+    : lru_(*object.lrus(), std::move(compressor)), config_(*object.config()) {}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+bool MMS3FIFO::Container<T, HookPtr>::recordAccess(T& node,
+                                                    AccessMode mode) noexcept {
+  if ((mode == AccessMode::kWrite && !config_.updateOnWrite) ||
+      (mode == AccessMode::kRead && !config_.updateOnRead)) {
+    return false;
+  }
+
+  const auto curr = static_cast<Time>(util::getCurrentTimeSec());
+  // check if the node is still being memory managed
+  if (node.isInMMContainer() && !isAccessed(node)) {
+    if (!isAccessed(node)) {
+      markAccessed(node);
+    }
+    LockHolder l(lruMutex_, std::defer_lock);
+    l.lock();
+    if (!l.owns_lock()) {
+      return false;
+    }
+    if (!node.isInMMContainer()) {
+      return false;
+    }
+    setUpdateTime(node, curr);
+    return true;
+  }
+  return false;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+cachelib::EvictionAgeStat MMS3FIFO::Container<T, HookPtr>::getEvictionAgeStat(
+    uint64_t projectedLength) const noexcept {
+  LockHolder l(lruMutex_);
+  return getEvictionAgeStatLocked(projectedLength);
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+cachelib::EvictionAgeStat
+MMS3FIFO::Container<T, HookPtr>::getEvictionAgeStatLocked(
+    uint64_t projectedLength) const noexcept {
+  EvictionAgeStat stat;
+  const auto curr = static_cast<Time>(util::getCurrentTimeSec());
+
+  auto& list = lru_.getList(LruType::Main);
+  auto it = list.rbegin();
+  stat.warmQueueStat.oldestElementAge =
+      it != list.rend() ? curr - getUpdateTime(*it) : 0;
+  stat.warmQueueStat.size = list.size();
+  for (size_t numSeen = 0; numSeen < projectedLength && it != list.rend();
+       ++numSeen, ++it) {
+  }
+  stat.warmQueueStat.projectedAge = it != list.rend()
+                                        ? curr - getUpdateTime(*it)
+                                        : stat.warmQueueStat.oldestElementAge;
+  return stat;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+bool MMS3FIFO::Container<T, HookPtr>::add(T& node) noexcept {
+  const auto currTime = static_cast<Time>(util::getCurrentTimeSec());
+  LockHolder l(lruMutex_);
+  if (node.isInMMContainer()) {
+    return false;
+  }
+
+  auto& tinyLru = lru_.getList(LruType::Tiny);
+  tinyLru.linkAtHead(node);
+  markTiny(node);
+
+  // If tiny cache is full, unconditionally promote tail to main cache.
+  const auto expectedSize = config_.tinySizePercent * lru_.size() / 100;
+  if (lru_.getList(LruType::Tiny).size() > expectedSize) {
+    auto tailNode = tinyLru.getTail();
+    tinyLru.remove(*tailNode);
+
+    auto& mainLru = lru_.getList(LruType::Main);
+    mainLru.linkAtHead(*tailNode);
+    unmarkTiny(*tailNode);
+  }
+
+  node.markInMMContainer();
+  setUpdateTime(node, currTime);
+  unmarkAccessed(node);
+  return true;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+typename MMS3FIFO::Container<T, HookPtr>::LockedIterator
+MMS3FIFO::Container<T, HookPtr>::getEvictionIterator() const noexcept {
+  LockHolder l(lruMutex_);
+  return LockedIterator{std::move(l), *this};
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+template <typename F>
+void MMS3FIFO::Container<T, HookPtr>::withEvictionIterator(F&& fun) {
+  // uses spin lock which does not support combined locking
+  fun(getEvictionIterator());
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+template <typename F>
+void MMS3FIFO::Container<T, HookPtr>::withContainerLock(F&& fun) {
+  LockHolder l(lruMutex_);
+  fun();
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+void MMS3FIFO::Container<T, HookPtr>::removeLocked(T& node) noexcept {
+  if (isTiny(node)) {
+    lru_.getList(LruType::Tiny).remove(node);
+    unmarkTiny(node);
+  } else {
+    lru_.getList(LruType::Main).remove(node);
+  }
+
+  unmarkAccessed(node);
+  node.unmarkInMMContainer();
+  return;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+bool MMS3FIFO::Container<T, HookPtr>::remove(T& node) noexcept {
+  LockHolder l(lruMutex_);
+  if (!node.isInMMContainer()) {
+    return false;
+  }
+  removeLocked(node);
+  return true;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+void MMS3FIFO::Container<T, HookPtr>::remove(LockedIterator& it) noexcept {
+  T& node = *it;
+  XDCHECK(node.isInMMContainer());
+  ++it;
+  removeLocked(node);
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+bool MMS3FIFO::Container<T, HookPtr>::replace(T& oldNode, T& newNode) noexcept {
+  LockHolder l(lruMutex_);
+  if (!oldNode.isInMMContainer() || newNode.isInMMContainer()) {
+    return false;
+  }
+  const auto updateTime = getUpdateTime(oldNode);
+
+  if (isTiny(oldNode)) {
+    lru_.getList(LruType::Tiny).replace(oldNode, newNode);
+    unmarkTiny(oldNode);
+    markTiny(newNode);
+  } else {
+    lru_.getList(LruType::Main).replace(oldNode, newNode);
+  }
+
+  oldNode.unmarkInMMContainer();
+  newNode.markInMMContainer();
+  setUpdateTime(newNode, updateTime);
+  if (isAccessed(oldNode)) {
+    markAccessed(newNode);
+  } else {
+    unmarkAccessed(newNode);
+  }
+  return true;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+typename MMS3FIFO::Config MMS3FIFO::Container<T, HookPtr>::getConfig() const {
+  LockHolder l(lruMutex_);
+  return config_;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+void MMS3FIFO::Container<T, HookPtr>::setConfig(const Config& c) {
+  LockHolder l(lruMutex_);
+  config_ = c;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+serialization::MMS3FIFOObject MMS3FIFO::Container<T, HookPtr>::saveState()
+    const noexcept {
+  serialization::MMS3FIFOConfig configObject;
+  *configObject.updateOnWrite() = config_.updateOnWrite;
+  *configObject.updateOnRead() = config_.updateOnRead;
+  *configObject.ghostSizePercent() = config_.ghostSizePercent;
+  *configObject.tinySizePercent() = config_.tinySizePercent;
+  // TODO: Serialize the ghost queue too.
+  serialization::MMS3FIFOObject object;
+  *object.config() = configObject;
+  *object.lrus() = lru_.saveState();
+  return object;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+MMContainerStat MMS3FIFO::Container<T, HookPtr>::getStats() const noexcept {
+  LockHolder l(lruMutex_);
+  auto* tail = lru_.size() == 0 ? nullptr : lru_.rbegin().get();
+
+  auto stat = getEvictionAgeStatLocked(0);
+  return {lru_.size(),
+          tail == nullptr ? 0 : getUpdateTime(*tail),
+          stat.warmQueueStat.oldestElementAge,
+          0,
+          0,
+          0,
+          0};
+}
+
+// Locked Iterator Context Implementation
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+MMS3FIFO::Container<T, HookPtr>::LockedIterator::LockedIterator(
+    LockHolder l, const Container<T, HookPtr>& c) noexcept
+    : c_(c),
+      tIter_(c.lru_.getList(LruType::Tiny).rbegin()),
+      mIter_(c.lru_.getList(LruType::Main).rbegin()),
+      l_(std::move(l)) {}
+} // namespace facebook::cachelib

--- a/cachelib/allocator/MMS3FIFO_v0.h
+++ b/cachelib/allocator/MMS3FIFO_v0.h
@@ -1,0 +1,605 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#include <folly/Format.h>
+#include <folly/Math.h>
+#pragma GCC diagnostic pop
+
+#include "cachelib/allocator/Cache.h"
+#include "cachelib/allocator/CacheStats.h"
+#include "cachelib/allocator/Util.h"
+#include "cachelib/allocator/datastruct/MultiDList.h"
+#include "cachelib/allocator/memory/serialize/gen-cpp2/objects_types.h"
+#include "cachelib/common/CompilerUtils.h"
+#include "cachelib/common/Mutex.h"
+
+namespace facebook::cachelib {
+// MMS3FIFOV0
+// This version is TinyLFU stripped down to basic FIFO functionality
+// Notes include:
+// 1. No lock in recordAccess
+class MMS3FIFO {
+ public:
+  // unique identifier per MMType
+  static const int kId;
+
+  // forward declaration;
+  template <typename T>
+  using Hook = DListHook<T>;
+  using SerializationType = serialization::MMS3FIFOObject;
+  using SerializationConfigType = serialization::MMS3FIFOConfig;
+  using SerializationTypeContainer = serialization::MMS3FIFOCollection;
+
+  enum LruType { Main, Tiny, NumTypes };
+
+  // Config class for MMS3FIFO
+  struct Config {
+    // create from serialized config
+    explicit Config(SerializationConfigType configState)
+        : Config(*configState.updateOnWrite(),
+                 *configState.updateOnRead(),
+                 *configState.tinySizePercent(),
+                 *configState.ghostSizePercent()) {}
+
+    // @param udpateOnW   whether to promote the item on write
+    // @param updateOnR   whether to promote the item on read
+    Config(bool updateOnW, bool updateOnR)
+        : Config(updateOnW, updateOnR, 10, 90) {}
+
+    // @param udpateOnW         whether to promote the item on write
+    // @param updateOnR         whether to promote the item on read
+    // @param tinySizePercent   percentage number of tiny size to overall size
+    // @param ghostSizePercent  percentage number of ghost size to main size
+    Config(bool updateOnW,
+           bool updateOnR,
+           size_t tinySizePercent,
+           size_t ghostSizePercent)
+        : updateOnWrite(updateOnW),
+          updateOnRead(updateOnR),
+          tinySizePercent(tinySizePercent),
+          ghostSizePercent(ghostSizePercent) {}
+
+    Config() = default;
+    Config(const Config& rhs) = default;
+    Config(Config&& rhs) = default;
+
+    Config& operator=(const Config& rhs) = default;
+    Config& operator=(Config&& rhs) = default;
+
+    template <typename... Args>
+    void addExtraConfig(Args...) {}
+
+    // whether the lru needs to be updated on writes for recordAccess. If
+    // false, accessing the cache for writes does not promote the cached item
+    // to the head of the lru.
+    bool updateOnWrite{false};
+
+    // whether the lru needs to be updated on reads for recordAccess. If
+    // false, accessing the cache for reads does not promote the cached item
+    // to the head of the lru.
+    bool updateOnRead{true};
+
+    // The size of tiny cache, as a percentage of the total size.
+    size_t tinySizePercent{10};
+
+    size_t ghostSizePercent{90};
+  };
+
+  // The container object which can be used to keep track of objects of type
+  // T. T must have a public member of type Hook. This object is wrapper
+  // around DList, is thread safe and can be accessed from multiple threads.
+  // The current implementation models an LRU using the above DList
+  // implementation.
+  template <typename T, Hook<T> T::* HookPtr>
+  struct Container {
+   private:
+    using LruList = MultiDList<T, HookPtr>;
+    using Mutex = folly::SpinLock;
+    using LockHolder = std::unique_lock<Mutex>;
+    using PtrCompressor = typename T::PtrCompressor;
+    using Time = typename Hook<T>::Time;
+    using CompressedPtrType = typename T::CompressedPtrType;
+    using RefFlags = typename T::Flags;
+
+   public:
+    Container() = default;
+    Container(Config c, PtrCompressor compressor)
+        : lru_(LruType::NumTypes, std::move(compressor)),
+          config_(std::move(c)) {}
+    Container(serialization::MMS3FIFOObject object, PtrCompressor compressor);
+
+    Container(const Container&) = delete;
+    Container& operator=(const Container&) = delete;
+
+    // records the information that the node was accessed. This could bump up
+    // the node to the head of the lru depending on the time when the node was
+    // last updated in lru and the kLruRefreshTime. If the node was moved to
+    // the head in the lru, the node's updateTime will be updated
+    // accordingly.
+    //
+    // @param node  node that we want to mark as relevant/accessed
+    // @param mode  the mode for the access operation.
+    //
+    // @return      True if the information is recorded and bumped the node
+    //              to the head of the lru, returns false otherwise
+    bool recordAccess(T& node, AccessMode mode) noexcept;
+
+    // adds the given node into the container and marks it as being present in
+    // the container. The node is added to the head of the lru.
+    //
+    // @param node  The node to be added to the container.
+    // @return  True if the node was successfully added to the container. False
+    //          if the node was already in the contianer. On error state of node
+    //          is unchanged.
+    bool add(T& node) noexcept;
+
+    // removes the node from the lru and sets it previous and next to nullptr.
+    //
+    // @param node  The node to be removed from the container.
+    // @return  True if the node was successfully removed from the container.
+    //          False if the node was not part of the container. On error, the
+    //          state of node is unchanged.
+    bool remove(T& node) noexcept;
+
+    class LockedIterator;
+    // same as the above but uses an iterator context. The iterator is updated
+    // on removal of the corresponding node to point to the next node. The
+    // iterator context holds the lock on the lru.
+    //
+    // iterator will be advanced to the next node after removing the node
+    //
+    // @param it    Iterator that will be removed
+    void remove(LockedIterator& it) noexcept;
+
+    // replaces one node with another, at the same position
+    //
+    // @param oldNode   node being replaced
+    // @param newNode   node to replace oldNode with
+    //
+    // @return true  If the replace was successful. Returns false if the
+    //               destination node did not exist in the container, or if the
+    //               source node already existed.
+    bool replace(T& oldNode, T& newNode) noexcept;
+
+    // context for iterating the MM container. At any given point of time,
+    // there can be only one iterator active since we need to lock the LRU for
+    // iteration. we can support multiple iterators at same time, by using a
+    // shared ptr in the context for the lock holder in the future.
+    class LockedIterator {
+     public:
+      using ListIterator = typename LruList::DListIterator;
+      // noncopyable but movable.
+      LockedIterator(const LockedIterator&) = delete;
+      LockedIterator& operator=(const LockedIterator&) = delete;
+      LockedIterator(LockedIterator&&) noexcept = default;
+
+      LockedIterator& operator++() noexcept {
+        ++getIter();
+        return *this;
+      }
+
+      LockedIterator& operator--() {
+        throw std::invalid_argument(
+            "Decrementing eviction iterator is not supported");
+      }
+
+      T* operator->() const noexcept { return getIter().operator->(); }
+      T& operator*() const noexcept { return getIter().operator*(); }
+
+      bool operator==(const LockedIterator& other) const noexcept {
+        return &c_ == &other.c_ && tIter_ == other.tIter_ &&
+               mIter_ == other.mIter_;
+      }
+
+      bool operator!=(const LockedIterator& other) const noexcept {
+        return !(*this == other);
+      }
+
+      explicit operator bool() const noexcept { return tIter_ || mIter_; }
+
+      T* get() const noexcept { return getIter().get(); }
+
+      // Invalidates this iterator
+      void reset() noexcept {
+        // Point iterator to first list's rend
+        tIter_.reset();
+        mIter_.reset();
+      }
+
+      // 1. Invalidate this iterator
+      // 2. Unlock
+      void destroy() {
+        reset();
+        if (l_.owns_lock()) {
+          l_.unlock();
+        }
+      }
+
+      // Reset this iterator to the beginning
+      void resetToBegin() {
+        if (!l_.owns_lock()) {
+          l_.lock();
+        }
+        tIter_.resetToBegin();
+        mIter_.resetToBegin();
+      }
+
+     private:
+      // private because it's easy to misuse and cause deadlock for MMS3FIFO
+      LockedIterator& operator=(LockedIterator&&) noexcept = default;
+
+      // create an lru iterator with the lock being held.
+      explicit LockedIterator(LockHolder l,
+                              const Container<T, HookPtr>& c) noexcept;
+
+      const ListIterator& getIter() const noexcept {
+        return evictTiny() ? tIter_ : mIter_;
+      }
+
+      ListIterator& getIter() noexcept {
+        return const_cast<ListIterator&>(
+            static_cast<const LockedIterator*>(this)->getIter());
+      }
+
+      bool evictTiny() const noexcept {
+        if (!mIter_) {
+          return true;
+        }
+        if (!tIter_) {
+          return false;
+        }
+
+        const auto expectedSize =
+            c_.config_.tinySizePercent * c_.lru_.size() / 100;
+        auto isTinyBig = c_.lru_.getList(LruType::Tiny).size() > expectedSize;
+        return isTinyBig;
+      }
+
+      // only the container can create iterators
+      friend Container<T, HookPtr>;
+
+      const Container<T, HookPtr>& c_;
+      // Tiny and main cache iterators
+      ListIterator tIter_;
+      ListIterator mIter_;
+      // lock protecting the validity of the iterator
+      LockHolder l_;
+    };
+
+    Config getConfig() const;
+
+    void setConfig(const Config& newConfig);
+
+    bool isEmpty() const noexcept {
+      LockHolder l(lruMutex_);
+      return lru_.size() == 0;
+    }
+
+    size_t size() const noexcept {
+      LockHolder l(lruMutex_);
+      return lru_.size();
+    }
+
+    // Returns the eviction age stats. See CacheStats.h for details
+    EvictionAgeStat getEvictionAgeStat(uint64_t projectedLength) const noexcept;
+
+    // Obtain an iterator that start from the tail and can be used
+    // to search for evictions. This iterator holds a lock to this
+    // container and only one such iterator can exist at a time
+    LockedIterator getEvictionIterator() const noexcept;
+
+    // Execute provided function under container lock. Function gets
+    // iterator passed as parameter.
+    template <typename F>
+    void withEvictionIterator(F&& f);
+
+    // Execute provided function under container lock.
+    template <typename F>
+    void withContainerLock(F&& f);
+
+    // for saving the state of the lru
+    //
+    // precondition:  serialization must happen without any reader or writer
+    // present. Any modification of this object afterwards will result in an
+    // invalid, inconsistent state for the serialized data.
+    //
+    serialization::MMS3FIFOObject saveState() const noexcept;
+
+    // return the stats for this container.
+    MMContainerStat getStats() const noexcept;
+
+    static LruType getLruType(const T& node) noexcept {
+      return isTiny(node) ? LruType::Tiny : LruType::Main;
+    }
+
+   private:
+    EvictionAgeStat getEvictionAgeStatLocked(
+        uint64_t projectedLength) const noexcept;
+
+    static Time getUpdateTime(const T& node) noexcept {
+      return (node.*HookPtr).getUpdateTime();
+    }
+
+    static void setUpdateTime(T& node, Time time) noexcept {
+      (node.*HookPtr).setUpdateTime(time);
+    }
+
+    // Returns the hash of node's key
+    static size_t hashNode(const T& node) noexcept {
+      return folly::hasher<folly::StringPiece>()(node.getKey());
+    }
+
+    // remove node from lru and adjust insertion points
+    //
+    // @param node          node to remove
+    void removeLocked(T& node) noexcept;
+
+    static bool isTiny(const T& node) noexcept {
+      return node.template isFlagSet<RefFlags::kMMFlag0>();
+    }
+
+    static bool isAccessed(const T& node) noexcept {
+      return node.template isFlagSet<RefFlags::kMMFlag1>();
+    }
+
+    // Bit MM_BIT_0 is used to record if the item is in tiny cache.
+    static void markTiny(T& node) noexcept {
+      node.template setFlag<RefFlags::kMMFlag0>();
+    }
+    static void unmarkTiny(T& node) noexcept {
+      node.template unSetFlag<RefFlags::kMMFlag0>();
+    }
+
+    // Bit MM_BIT_1 is used to record if the item has been accessed since being
+    // written in cache. Unaccessed items are ignored when determining projected
+    // update time.
+    static void markAccessed(T& node) noexcept {
+      node.template setFlag<RefFlags::kMMFlag1>();
+    }
+    static void unmarkAccessed(T& node) noexcept {
+      node.template unSetFlag<RefFlags::kMMFlag1>();
+    }
+
+    mutable Mutex lruMutex_;
+
+    // the lru
+    LruList lru_;
+
+    // Current capacity to track ghost size
+    size_t capacity_{0};
+
+    // Config for this lru.
+    // Write access to the MMS3FIFO Config is serialized.
+    // Reads may be racy.
+    Config config_{};
+
+    // FRIEND_TEST(MMTinyLFUTest, SegmentStress);
+    // FRIEND_TEST(MMTinyLFUTest, TinyLFUBasic);
+    // FRIEND_TEST(MMTinyLFUTest, Reconfigure);
+  };
+};
+
+/* Container Interface Implementation */
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+MMS3FIFO::Container<T, HookPtr>::Container(serialization::MMS3FIFOObject object,
+                                           PtrCompressor compressor)
+    : lru_(*object.lrus(), std::move(compressor)), config_(*object.config()) {}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+bool MMS3FIFO::Container<T, HookPtr>::recordAccess(T& node,
+                                                   AccessMode mode) noexcept {
+  if ((mode == AccessMode::kWrite && !config_.updateOnWrite) ||
+      (mode == AccessMode::kRead && !config_.updateOnRead)) {
+    return false;
+  }
+
+  const auto curr = static_cast<Time>(util::getCurrentTimeSec());
+  // check if the node is still being memory managed
+  if (node.isInMMContainer() && !isAccessed(node)) {
+    markAccessed(node);
+    setUpdateTime(node, curr);
+    return true;
+  }
+  return false;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+cachelib::EvictionAgeStat MMS3FIFO::Container<T, HookPtr>::getEvictionAgeStat(
+    uint64_t projectedLength) const noexcept {
+  LockHolder l(lruMutex_);
+  return getEvictionAgeStatLocked(projectedLength);
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+cachelib::EvictionAgeStat
+MMS3FIFO::Container<T, HookPtr>::getEvictionAgeStatLocked(
+    uint64_t projectedLength) const noexcept {
+  EvictionAgeStat stat;
+  const auto curr = static_cast<Time>(util::getCurrentTimeSec());
+
+  auto& list = lru_.getList(LruType::Main);
+  auto it = list.rbegin();
+  stat.warmQueueStat.oldestElementAge =
+      it != list.rend() ? curr - getUpdateTime(*it) : 0;
+  stat.warmQueueStat.size = list.size();
+  for (size_t numSeen = 0; numSeen < projectedLength && it != list.rend();
+       ++numSeen, ++it) {
+  }
+  stat.warmQueueStat.projectedAge = it != list.rend()
+                                        ? curr - getUpdateTime(*it)
+                                        : stat.warmQueueStat.oldestElementAge;
+  return stat;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+bool MMS3FIFO::Container<T, HookPtr>::add(T& node) noexcept {
+  const auto currTime = static_cast<Time>(util::getCurrentTimeSec());
+  LockHolder l(lruMutex_);
+  if (node.isInMMContainer()) {
+    return false;
+  }
+
+  auto& tinyLru = lru_.getList(LruType::Tiny);
+  tinyLru.linkAtHead(node);
+  markTiny(node);
+
+  // If tiny cache is full, unconditionally promote tail to main cache.
+  const auto expectedSize = config_.tinySizePercent * lru_.size() / 100;
+  if (lru_.getList(LruType::Tiny).size() > expectedSize) {
+    auto tailNode = tinyLru.getTail();
+    tinyLru.remove(*tailNode);
+
+    auto& mainLru = lru_.getList(LruType::Main);
+    mainLru.linkAtHead(*tailNode);
+    unmarkTiny(*tailNode);
+  }
+
+  node.markInMMContainer();
+  setUpdateTime(node, currTime);
+  unmarkAccessed(node);
+  return true;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+typename MMS3FIFO::Container<T, HookPtr>::LockedIterator
+MMS3FIFO::Container<T, HookPtr>::getEvictionIterator() const noexcept {
+  LockHolder l(lruMutex_);
+  return LockedIterator{std::move(l), *this};
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+template <typename F>
+void MMS3FIFO::Container<T, HookPtr>::withEvictionIterator(F&& fun) {
+  // uses spin lock which does not support combined locking
+  fun(getEvictionIterator());
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+template <typename F>
+void MMS3FIFO::Container<T, HookPtr>::withContainerLock(F&& fun) {
+  LockHolder l(lruMutex_);
+  fun();
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+void MMS3FIFO::Container<T, HookPtr>::removeLocked(T& node) noexcept {
+  if (isTiny(node)) {
+    lru_.getList(LruType::Tiny).remove(node);
+    unmarkTiny(node);
+  } else {
+    lru_.getList(LruType::Main).remove(node);
+  }
+
+  unmarkAccessed(node);
+  node.unmarkInMMContainer();
+  return;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+bool MMS3FIFO::Container<T, HookPtr>::remove(T& node) noexcept {
+  LockHolder l(lruMutex_);
+  if (!node.isInMMContainer()) {
+    return false;
+  }
+  removeLocked(node);
+  return true;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+void MMS3FIFO::Container<T, HookPtr>::remove(LockedIterator& it) noexcept {
+  T& node = *it;
+  XDCHECK(node.isInMMContainer());
+  ++it;
+  removeLocked(node);
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+bool MMS3FIFO::Container<T, HookPtr>::replace(T& oldNode, T& newNode) noexcept {
+  LockHolder l(lruMutex_);
+  if (!oldNode.isInMMContainer() || newNode.isInMMContainer()) {
+    return false;
+  }
+  const auto updateTime = getUpdateTime(oldNode);
+
+  if (isTiny(oldNode)) {
+    lru_.getList(LruType::Tiny).replace(oldNode, newNode);
+    unmarkTiny(oldNode);
+    markTiny(newNode);
+  } else {
+    lru_.getList(LruType::Main).replace(oldNode, newNode);
+  }
+
+  oldNode.unmarkInMMContainer();
+  newNode.markInMMContainer();
+  setUpdateTime(newNode, updateTime);
+  if (isAccessed(oldNode)) {
+    markAccessed(newNode);
+  } else {
+    unmarkAccessed(newNode);
+  }
+  return true;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+typename MMS3FIFO::Config MMS3FIFO::Container<T, HookPtr>::getConfig() const {
+  LockHolder l(lruMutex_);
+  return config_;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+void MMS3FIFO::Container<T, HookPtr>::setConfig(const Config& c) {
+  LockHolder l(lruMutex_);
+  config_ = c;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+serialization::MMS3FIFOObject MMS3FIFO::Container<T, HookPtr>::saveState()
+    const noexcept {
+  serialization::MMS3FIFOConfig configObject;
+  *configObject.updateOnWrite() = config_.updateOnWrite;
+  *configObject.updateOnRead() = config_.updateOnRead;
+  *configObject.ghostSizePercent() = config_.ghostSizePercent;
+  *configObject.tinySizePercent() = config_.tinySizePercent;
+  // TODO: Serialize the ghost queue too.
+  serialization::MMS3FIFOObject object;
+  *object.config() = configObject;
+  *object.lrus() = lru_.saveState();
+  return object;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+MMContainerStat MMS3FIFO::Container<T, HookPtr>::getStats() const noexcept {
+  LockHolder l(lruMutex_);
+  auto* tail = lru_.size() == 0 ? nullptr : lru_.rbegin().get();
+  return {
+      lru_.size(), tail == nullptr ? 0 : getUpdateTime(*tail), 0, 0, 0, 0, 0};
+}
+
+// Locked Iterator Context Implementation
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+MMS3FIFO::Container<T, HookPtr>::LockedIterator::LockedIterator(
+    LockHolder l, const Container<T, HookPtr>& c) noexcept
+    : c_(c),
+      tIter_(c.lru_.getList(LruType::Tiny).rbegin()),
+      mIter_(c.lru_.getList(LruType::Main).rbegin()),
+      l_(std::move(l)) {}
+} // namespace facebook::cachelib

--- a/cachelib/allocator/MMS3FIFO_v1.h
+++ b/cachelib/allocator/MMS3FIFO_v1.h
@@ -1,0 +1,653 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#include <folly/Format.h>
+#include <folly/Math.h>
+#pragma GCC diagnostic pop
+
+#include "cachelib/allocator/Cache.h"
+#include "cachelib/allocator/CacheStats.h"
+#include "cachelib/allocator/Util.h"
+#include "cachelib/allocator/datastruct/MultiDList.h"
+#include "cachelib/allocator/memory/serialize/gen-cpp2/objects_types.h"
+#include "cachelib/common/CompilerUtils.h"
+#include "cachelib/common/Mutex.h"
+
+namespace facebook::cachelib {
+// MM S3FIFO V1
+// This version modifies v0 and introduces a promotion policy.
+// Only items that are unaccessed will be evicted
+// Iterator will skip accessed items during eviction search
+class MMS3FIFO {
+ public:
+  // unique identifier per MMType
+  static const int kId;
+
+  // forward declaration;
+  template <typename T>
+  using Hook = DListHook<T>;
+  using SerializationType = serialization::MMS3FIFOObject;
+  using SerializationConfigType = serialization::MMS3FIFOConfig;
+  using SerializationTypeContainer = serialization::MMS3FIFOCollection;
+
+  enum LruType { Main, Tiny, NumTypes };
+
+  // Config class for MMS3FIFO
+  struct Config {
+    // create from serialized config
+    explicit Config(SerializationConfigType configState)
+        : Config(*configState.updateOnWrite(),
+                 *configState.updateOnRead(),
+                 *configState.tinySizePercent(),
+                 *configState.ghostSizePercent()) {}
+
+    // @param udpateOnW   whether to promote the item on write
+    // @param updateOnR   whether to promote the item on read
+    Config(bool updateOnW, bool updateOnR)
+        : Config(updateOnW, updateOnR, 10, 90) {}
+
+    // @param udpateOnW         whether to promote the item on write
+    // @param updateOnR         whether to promote the item on read
+    // @param tinySizePercent   percentage number of tiny size to overall size
+    // @param ghostSizePercent  percentage number of ghost size to main size
+    Config(bool updateOnW,
+           bool updateOnR,
+           size_t tinySizePercent,
+           size_t ghostSizePercent)
+        : updateOnWrite(updateOnW),
+          updateOnRead(updateOnR),
+          tinySizePercent(tinySizePercent),
+          ghostSizePercent(ghostSizePercent) {}
+
+    Config() = default;
+    Config(const Config& rhs) = default;
+    Config(Config&& rhs) = default;
+
+    Config& operator=(const Config& rhs) = default;
+    Config& operator=(Config&& rhs) = default;
+
+    template <typename... Args>
+    void addExtraConfig(Args...) {}
+
+    // whether the lru needs to be updated on writes for recordAccess. If
+    // false, accessing the cache for writes does not promote the cached item
+    // to the head of the lru.
+    bool updateOnWrite{false};
+
+    // whether the lru needs to be updated on reads for recordAccess. If
+    // false, accessing the cache for reads does not promote the cached item
+    // to the head of the lru.
+    bool updateOnRead{true};
+
+    // The size of tiny cache, as a percentage of the total size.
+    size_t tinySizePercent{10};
+
+    size_t ghostSizePercent{90};
+  };
+
+  // The container object which can be used to keep track of objects of type
+  // T. T must have a public member of type Hook. This object is wrapper
+  // around DList, is thread safe and can be accessed from multiple threads.
+  // The current implementation models an LRU using the above DList
+  // implementation.
+  template <typename T, Hook<T> T::* HookPtr>
+  struct Container {
+   private:
+    using LruList = MultiDList<T, HookPtr>;
+    using Mutex = folly::SpinLock;
+    using LockHolder = std::unique_lock<Mutex>;
+    using PtrCompressor = typename T::PtrCompressor;
+    using Time = typename Hook<T>::Time;
+    using CompressedPtrType = typename T::CompressedPtrType;
+    using RefFlags = typename T::Flags;
+
+   public:
+    Container() = default;
+    Container(Config c, PtrCompressor compressor)
+        : lru_(LruType::NumTypes, std::move(compressor)),
+          config_(std::move(c)) {}
+    Container(serialization::MMS3FIFOObject object, PtrCompressor compressor);
+
+    Container(const Container&) = delete;
+    Container& operator=(const Container&) = delete;
+
+    // records the information that the node was accessed. This could bump up
+    // the node to the head of the lru depending on the time when the node was
+    // last updated in lru and the kLruRefreshTime. If the node was moved to
+    // the head in the lru, the node's updateTime will be updated
+    // accordingly.
+    //
+    // @param node  node that we want to mark as relevant/accessed
+    // @param mode  the mode for the access operation.
+    //
+    // @return      True if the information is recorded and bumped the node
+    //              to the head of the lru, returns false otherwise
+    bool recordAccess(T& node, AccessMode mode) noexcept;
+
+    // adds the given node into the container and marks it as being present in
+    // the container. The node is added to the head of the lru.
+    //
+    // @param node  The node to be added to the container.
+    // @return  True if the node was successfully added to the container. False
+    //          if the node was already in the contianer. On error state of node
+    //          is unchanged.
+    bool add(T& node) noexcept;
+
+    // removes the node from the lru and sets it previous and next to nullptr.
+    //
+    // @param node  The node to be removed from the container.
+    // @return  True if the node was successfully removed from the container.
+    //          False if the node was not part of the container. On error, the
+    //          state of node is unchanged.
+    bool remove(T& node) noexcept;
+
+    class LockedIterator;
+    // same as the above but uses an iterator context. The iterator is updated
+    // on removal of the corresponding node to point to the next node. The
+    // iterator context holds the lock on the lru.
+    //
+    // iterator will be advanced to the next node after removing the node
+    //
+    // @param it    Iterator that will be removed
+    void remove(LockedIterator& it) noexcept;
+
+    // replaces one node with another, at the same position
+    //
+    // @param oldNode   node being replaced
+    // @param newNode   node to replace oldNode with
+    //
+    // @return true  If the replace was successful. Returns false if the
+    //               destination node did not exist in the container, or if the
+    //               source node already existed.
+    bool replace(T& oldNode, T& newNode) noexcept;
+
+    // context for iterating the MM container. At any given point of time,
+    // there can be only one iterator active since we need to lock the LRU for
+    // iteration. we can support multiple iterators at same time, by using a
+    // shared ptr in the context for the lock holder in the future.
+    class LockedIterator {
+     public:
+      using ListIterator = typename LruList::DListIterator;
+      // noncopyable but movable.
+      LockedIterator(const LockedIterator&) = delete;
+      LockedIterator& operator=(const LockedIterator&) = delete;
+      LockedIterator(LockedIterator&&) noexcept = default;
+
+      LockedIterator& operator++() noexcept {
+        auto it = ++getIter();
+        skipAccessed(it);
+        return *this;
+      }
+
+      void skipAccessed(ListIterator& it) noexcept {
+        while (it) {
+          T& node = *it;
+          if (!Container<T, HookPtr>::isAccessed(node)) {
+            break; // found a valid eviction victim
+          }
+          ++it; // skip this accessed item
+        }
+      }
+
+      LockedIterator& operator--() {
+        throw std::invalid_argument(
+            "Decrementing eviction iterator is not supported");
+      }
+
+      T* operator->() const noexcept { return getIter().operator->(); }
+      T& operator*() const noexcept { return getIter().operator*(); }
+
+      bool operator==(const LockedIterator& other) const noexcept {
+        return &c_ == &other.c_ && tIter_ == other.tIter_ &&
+               mIter_ == other.mIter_;
+      }
+
+      bool operator!=(const LockedIterator& other) const noexcept {
+        return !(*this == other);
+      }
+
+      explicit operator bool() const noexcept { return tIter_ || mIter_; }
+
+      T* get() const noexcept { return getIter().get(); }
+
+      // Invalidates this iterator
+      void reset() noexcept {
+        // Point iterator to first list's rend
+        tIter_.reset();
+        mIter_.reset();
+      }
+
+      // 1. Invalidate this iterator
+      // 2. Unlock
+      void destroy() {
+        reset();
+        if (l_.owns_lock()) {
+          l_.unlock();
+        }
+      }
+
+      // Reset this iterator to the beginning
+      void resetToBegin() {
+        if (!l_.owns_lock()) {
+          l_.lock();
+        }
+        tIter_.resetToBegin();
+        mIter_.resetToBegin();
+      }
+
+     private:
+      // private because it's easy to misuse and cause deadlock for MMS3FIFO
+      LockedIterator& operator=(LockedIterator&&) noexcept = default;
+
+      // create an lru iterator with the lock being held.
+      explicit LockedIterator(LockHolder l,
+                              const Container<T, HookPtr>& c) noexcept;
+
+      const ListIterator& getIter() const noexcept {
+        return evictTiny() ? tIter_ : mIter_;
+      }
+
+      ListIterator& getIter() noexcept {
+        return const_cast<ListIterator&>(
+            static_cast<const LockedIterator*>(this)->getIter());
+      }
+
+      bool evictTiny() const noexcept {
+        if (!mIter_) {
+          return true;
+        }
+        if (!tIter_) {
+          return false;
+        }
+
+        const auto expectedSize =
+            c_.config_.tinySizePercent * c_.lru_.size() / 100;
+        auto isTinyBig = c_.lru_.getList(LruType::Tiny).size() > expectedSize;
+        return isTinyBig;
+      }
+
+      // only the container can create iterators
+      friend Container<T, HookPtr>;
+
+      const Container<T, HookPtr>& c_;
+      // Tiny and main cache iterators
+      ListIterator tIter_;
+      ListIterator mIter_;
+      // lock protecting the validity of the iterator
+      LockHolder l_;
+    };
+
+    Config getConfig() const;
+
+    void setConfig(const Config& newConfig);
+
+    bool isEmpty() const noexcept {
+      LockHolder l(lruMutex_);
+      return lru_.size() == 0;
+    }
+
+    size_t size() const noexcept {
+      LockHolder l(lruMutex_);
+      return lru_.size();
+    }
+
+    // Returns the eviction age stats. See CacheStats.h for details
+    EvictionAgeStat getEvictionAgeStat(uint64_t projectedLength) const noexcept;
+
+    // Obtain an iterator that start from the tail and can be used
+    // to search for evictions. This iterator holds a lock to this
+    // container and only one such iterator can exist at a time
+    LockedIterator getEvictionIterator() noexcept;
+
+    // Execute provided function under container lock. Function gets
+    // iterator passed as parameter.
+    template <typename F>
+    void withEvictionIterator(F&& f);
+
+    // Execute provided function under container lock.
+    template <typename F>
+    void withContainerLock(F&& f);
+
+    // for saving the state of the lru
+    //
+    // precondition:  serialization must happen without any reader or writer
+    // present. Any modification of this object afterwards will result in an
+    // invalid, inconsistent state for the serialized data.
+    //
+    serialization::MMS3FIFOObject saveState() const noexcept;
+
+    // return the stats for this container.
+    MMContainerStat getStats() const noexcept;
+
+    static LruType getLruType(const T& node) noexcept {
+      return isTiny(node) ? LruType::Tiny : LruType::Main;
+    }
+
+   private:
+    EvictionAgeStat getEvictionAgeStatLocked(
+        uint64_t projectedLength) const noexcept;
+
+    static Time getUpdateTime(const T& node) noexcept {
+      return (node.*HookPtr).getUpdateTime();
+    }
+
+    static void setUpdateTime(T& node, Time time) noexcept {
+      (node.*HookPtr).setUpdateTime(time);
+    }
+
+    // Returns the hash of node's key
+    static size_t hashNode(const T& node) noexcept {
+      return folly::hasher<folly::StringPiece>()(node.getKey());
+    }
+
+    // remove node from lru and adjust insertion points
+    //
+    // @param node          node to remove
+    void removeLocked(T& node) noexcept;
+
+    static bool isTiny(const T& node) noexcept {
+      return node.template isFlagSet<RefFlags::kMMFlag0>();
+    }
+
+    static bool isAccessed(const T& node) noexcept {
+      return node.template isFlagSet<RefFlags::kMMFlag1>();
+    }
+
+    // Bit MM_BIT_0 is used to record if the item is in tiny cache.
+    static void markTiny(T& node) noexcept {
+      node.template setFlag<RefFlags::kMMFlag0>();
+    }
+    static void unmarkTiny(T& node) noexcept {
+      node.template unSetFlag<RefFlags::kMMFlag0>();
+    }
+
+    // Bit MM_BIT_1 is used to record if the item has been accessed since being
+    // written in cache. Unaccessed items are ignored when determining projected
+    // update time.
+    static void markAccessed(T& node) noexcept {
+      node.template setFlag<RefFlags::kMMFlag1>();
+    }
+    static void unmarkAccessed(T& node) noexcept {
+      node.template unSetFlag<RefFlags::kMMFlag1>();
+    }
+
+    void rebalanceForEviction();
+
+    mutable Mutex lruMutex_;
+
+    // the lru
+    LruList lru_;
+
+    // Current capacity to track ghost size
+    size_t capacity_{0};
+
+    // Config for this lru.
+    // Write access to the MMS3FIFO Config is serialized.
+    // Reads may be racy.
+    Config config_{};
+
+    // FRIEND_TEST(MMTinyLFUTest, SegmentStress);
+    // FRIEND_TEST(MMTinyLFUTest, TinyLFUBasic);
+    // FRIEND_TEST(MMTinyLFUTest, Reconfigure);
+  };
+};
+
+/* Container Interface Implementation */
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+MMS3FIFO::Container<T, HookPtr>::Container(serialization::MMS3FIFOObject object,
+                                           PtrCompressor compressor)
+    : lru_(*object.lrus(), std::move(compressor)), config_(*object.config()) {}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+bool MMS3FIFO::Container<T, HookPtr>::recordAccess(T& node,
+                                                   AccessMode mode) noexcept {
+  if ((mode == AccessMode::kWrite && !config_.updateOnWrite) ||
+      (mode == AccessMode::kRead && !config_.updateOnRead)) {
+    return false;
+  }
+
+  const auto curr = static_cast<Time>(util::getCurrentTimeSec());
+  // check if the node is still being memory managed
+  if (node.isInMMContainer() && !isAccessed(node)) {
+    markAccessed(node);
+    setUpdateTime(node, curr);
+    return true;
+  }
+  return false;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+cachelib::EvictionAgeStat MMS3FIFO::Container<T, HookPtr>::getEvictionAgeStat(
+    uint64_t projectedLength) const noexcept {
+  LockHolder l(lruMutex_);
+  return getEvictionAgeStatLocked(projectedLength);
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+cachelib::EvictionAgeStat
+MMS3FIFO::Container<T, HookPtr>::getEvictionAgeStatLocked(
+    uint64_t projectedLength) const noexcept {
+  EvictionAgeStat stat;
+  const auto curr = static_cast<Time>(util::getCurrentTimeSec());
+
+  auto& list = lru_.getList(LruType::Main);
+  auto it = list.rbegin();
+  stat.warmQueueStat.oldestElementAge =
+      it != list.rend() ? curr - getUpdateTime(*it) : 0;
+  stat.warmQueueStat.size = list.size();
+  for (size_t numSeen = 0; numSeen < projectedLength && it != list.rend();
+       ++numSeen, ++it) {
+  }
+  stat.warmQueueStat.projectedAge = it != list.rend()
+                                        ? curr - getUpdateTime(*it)
+                                        : stat.warmQueueStat.oldestElementAge;
+  return stat;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+bool MMS3FIFO::Container<T, HookPtr>::add(T& node) noexcept {
+  const auto currTime = static_cast<Time>(util::getCurrentTimeSec());
+  LockHolder l(lruMutex_);
+  if (node.isInMMContainer()) {
+    return false;
+  }
+
+  auto& tinyLru = lru_.getList(LruType::Tiny);
+  tinyLru.linkAtHead(node);
+
+  markTiny(node);
+  unmarkAccessed(node);
+  setUpdateTime(node, currTime);
+
+  node.markInMMContainer();
+  return true;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+void MMS3FIFO::Container<T, HookPtr>::rebalanceForEviction() {
+    // Bulk move accessed items from tiny to main cache
+    // Until tinycache's tail is unaccessed or tiny cache is within size limit
+    // Room for optimization:
+    // We can bulk move segments to main instead of one by one
+    auto& tinyLru = lru_.getList(LruType::Tiny);
+    auto& mainLru = lru_.getList(LruType::Main);
+
+    bool isTinyTailUnaccessed = false;
+    const auto expectedSize = config_.tinySizePercent * lru_.size() / 100;
+    while (!isTinyTailUnaccessed) {
+        if (tinyLru.size() <= expectedSize) {
+            break;
+        }
+        auto tailNode = tinyLru.getTail();
+        if (tailNode == nullptr || !isAccessed(*tailNode)) {
+            isTinyTailUnaccessed = true;
+            break;
+        }
+        tinyLru.remove(*tailNode);
+
+        mainLru.linkAtHead(*tailNode);
+        unmarkTiny(*tailNode);
+        unmarkAccessed(*tailNode);
+    }
+
+    // Reinsert items in main cache to head, until main cache's tail is unaccessed
+    // TODO: Room for optimization: 
+    // We can get the position of first unaccessed item from the tail
+    // And move the whole segment to head in one operation
+    bool isMainTailUnaccessed = false;
+    while (!isMainTailUnaccessed) {
+        auto tailNode = mainLru.getTail();
+        if (tailNode == nullptr || !isAccessed(*tailNode)) {
+            isMainTailUnaccessed = true;
+            break;
+        }
+        mainLru.remove(*tailNode);
+        mainLru.linkAtHead(*tailNode);
+        unmarkAccessed(*tailNode);
+    }
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+typename MMS3FIFO::Container<T, HookPtr>::LockedIterator
+MMS3FIFO::Container<T, HookPtr>::getEvictionIterator() noexcept {
+  LockHolder l(lruMutex_);
+  rebalanceForEviction();
+  return LockedIterator{std::move(l), *this};
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+template <typename F>
+void MMS3FIFO::Container<T, HookPtr>::withEvictionIterator(F&& fun) {
+  // uses spin lock which does not support combined locking
+  fun(getEvictionIterator());
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+template <typename F>
+void MMS3FIFO::Container<T, HookPtr>::withContainerLock(F&& fun) {
+  LockHolder l(lruMutex_);
+  fun();
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+void MMS3FIFO::Container<T, HookPtr>::removeLocked(T& node) noexcept {
+  if (isTiny(node)) {
+    lru_.getList(LruType::Tiny).remove(node);
+    unmarkTiny(node);
+  } else {
+    lru_.getList(LruType::Main).remove(node);
+  }
+
+  unmarkAccessed(node);
+  node.unmarkInMMContainer();
+  return;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+bool MMS3FIFO::Container<T, HookPtr>::remove(T& node) noexcept {
+  LockHolder l(lruMutex_);
+  if (!node.isInMMContainer()) {
+    return false;
+  }
+  removeLocked(node);
+  return true;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+void MMS3FIFO::Container<T, HookPtr>::remove(LockedIterator& it) noexcept {
+  T& node = *it;
+  XDCHECK(node.isInMMContainer());
+  ++it;
+  removeLocked(node);
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+bool MMS3FIFO::Container<T, HookPtr>::replace(T& oldNode, T& newNode) noexcept {
+  LockHolder l(lruMutex_);
+  if (!oldNode.isInMMContainer() || newNode.isInMMContainer()) {
+    return false;
+  }
+  const auto updateTime = getUpdateTime(oldNode);
+
+  if (isTiny(oldNode)) {
+    lru_.getList(LruType::Tiny).replace(oldNode, newNode);
+    unmarkTiny(oldNode);
+    markTiny(newNode);
+  } else {
+    lru_.getList(LruType::Main).replace(oldNode, newNode);
+  }
+
+  oldNode.unmarkInMMContainer();
+  newNode.markInMMContainer();
+  setUpdateTime(newNode, updateTime);
+  if (isAccessed(oldNode)) {
+    markAccessed(newNode);
+  } else {
+    unmarkAccessed(newNode);
+  }
+  return true;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+typename MMS3FIFO::Config MMS3FIFO::Container<T, HookPtr>::getConfig() const {
+  LockHolder l(lruMutex_);
+  return config_;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+void MMS3FIFO::Container<T, HookPtr>::setConfig(const Config& c) {
+  LockHolder l(lruMutex_);
+  config_ = c;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+serialization::MMS3FIFOObject MMS3FIFO::Container<T, HookPtr>::saveState()
+    const noexcept {
+  serialization::MMS3FIFOConfig configObject;
+  *configObject.updateOnWrite() = config_.updateOnWrite;
+  *configObject.updateOnRead() = config_.updateOnRead;
+  *configObject.ghostSizePercent() = config_.ghostSizePercent;
+  *configObject.tinySizePercent() = config_.tinySizePercent;
+  // TODO: Serialize the ghost queue too.
+  serialization::MMS3FIFOObject object;
+  *object.config() = configObject;
+  *object.lrus() = lru_.saveState();
+  return object;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+MMContainerStat MMS3FIFO::Container<T, HookPtr>::getStats() const noexcept {
+  LockHolder l(lruMutex_);
+  auto* tail = lru_.size() == 0 ? nullptr : lru_.rbegin().get();
+  return {
+      lru_.size(), tail == nullptr ? 0 : getUpdateTime(*tail), 0, 0, 0, 0, 0};
+}
+
+// Locked Iterator Context Implementation
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+MMS3FIFO::Container<T, HookPtr>::LockedIterator::LockedIterator(
+    LockHolder l, const Container<T, HookPtr>& c) noexcept
+    : c_(c),
+      tIter_(c.lru_.getList(LruType::Tiny).rbegin()),
+      mIter_(c.lru_.getList(LruType::Main).rbegin()),
+      l_(std::move(l)) {}
+} // namespace facebook::cachelib

--- a/cachelib/allocator/MMS3FIFO_v2.h
+++ b/cachelib/allocator/MMS3FIFO_v2.h
@@ -1,0 +1,688 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#include <folly/Format.h>
+#include <folly/Math.h>
+#pragma GCC diagnostic pop
+
+#include "cachelib/allocator/Cache.h"
+#include "cachelib/allocator/CacheStats.h"
+#include "cachelib/allocator/Util.h"
+#include "cachelib/allocator/datastruct/MultiDList.h"
+#include "cachelib/allocator/memory/serialize/gen-cpp2/objects_types.h"
+#include "cachelib/common/CompilerUtils.h"
+#include "cachelib/common/FIFOConcurrentHashSet.h"
+#include "cachelib/common/Mutex.h"
+
+namespace facebook::cachelib {
+//  MMS3FIFOV2
+// This adds a ghost queue to v1
+class MMS3FIFO {
+ public:
+  // unique identifier per MMType
+  static const int kId;
+
+  // forward declaration;
+  template <typename T>
+  using Hook = DListHook<T>;
+  using SerializationType = serialization::MMS3FIFOObject;
+  using SerializationConfigType = serialization::MMS3FIFOConfig;
+  using SerializationTypeContainer = serialization::MMS3FIFOCollection;
+
+  enum LruType { Main, Tiny, NumTypes };
+
+  // Config class for MMS3FIFO
+  struct Config {
+    // create from serialized config
+    explicit Config(SerializationConfigType configState)
+        : Config(*configState.updateOnWrite(),
+                 *configState.updateOnRead(),
+                 *configState.tinySizePercent(),
+                 *configState.ghostSizePercent()) {}
+
+    // @param udpateOnW   whether to promote the item on write
+    // @param updateOnR   whether to promote the item on read
+    Config(bool updateOnW, bool updateOnR)
+        : Config(updateOnW, updateOnR, 10, 90) {}
+
+    // @param udpateOnW         whether to promote the item on write
+    // @param updateOnR         whether to promote the item on read
+    // @param tinySizePercent   percentage number of tiny size to overall size
+    // @param ghostSizePercent  percentage number of ghost size to main size
+    Config(bool updateOnW,
+           bool updateOnR,
+           size_t tinySizePercent,
+           size_t ghostSizePercent)
+        : updateOnWrite(updateOnW),
+          updateOnRead(updateOnR),
+          tinySizePercent(tinySizePercent),
+          ghostSizePercent(ghostSizePercent) {}
+
+    Config() = default;
+    Config(const Config& rhs) = default;
+    Config(Config&& rhs) = default;
+
+    Config& operator=(const Config& rhs) = default;
+    Config& operator=(Config&& rhs) = default;
+
+    template <typename... Args>
+    void addExtraConfig(Args...) {}
+
+    // whether the lru needs to be updated on writes for recordAccess. If
+    // false, accessing the cache for writes does not promote the cached item
+    // to the head of the lru.
+    bool updateOnWrite{false};
+
+    // whether the lru needs to be updated on reads for recordAccess. If
+    // false, accessing the cache for reads does not promote the cached item
+    // to the head of the lru.
+    bool updateOnRead{true};
+
+    // The size of tiny cache, as a percentage of the total size.
+    size_t tinySizePercent{10};
+
+    size_t ghostSizePercent{90};
+  };
+
+  // The container object which can be used to keep track of objects of type
+  // T. T must have a public member of type Hook. This object is wrapper
+  // around DList, is thread safe and can be accessed from multiple threads.
+  // The current implementation models an LRU using the above DList
+  // implementation.
+  template <typename T, Hook<T> T::* HookPtr>
+  struct Container {
+   private:
+    using LruList = MultiDList<T, HookPtr>;
+    using Mutex = folly::SpinLock;
+    using LockHolder = std::unique_lock<Mutex>;
+    using PtrCompressor = typename T::PtrCompressor;
+    using Time = typename Hook<T>::Time;
+    using CompressedPtrType = typename T::CompressedPtrType;
+    using RefFlags = typename T::Flags;
+
+   public:
+    Container() = default;
+    Container(Config c, PtrCompressor compressor)
+        : lru_(LruType::NumTypes, std::move(compressor)),
+          config_(std::move(c)) {}
+    Container(serialization::MMS3FIFOObject object, PtrCompressor compressor);
+
+    Container(const Container&) = delete;
+    Container& operator=(const Container&) = delete;
+
+    // records the information that the node was accessed. This could bump up
+    // the node to the head of the lru depending on the time when the node was
+    // last updated in lru and the kLruRefreshTime. If the node was moved to
+    // the head in the lru, the node's updateTime will be updated
+    // accordingly.
+    //
+    // @param node  node that we want to mark as relevant/accessed
+    // @param mode  the mode for the access operation.
+    //
+    // @return      True if the information is recorded and bumped the node
+    //              to the head of the lru, returns false otherwise
+    bool recordAccess(T& node, AccessMode mode) noexcept;
+
+    // adds the given node into the container and marks it as being present in
+    // the container. The node is added to the head of the lru.
+    //
+    // @param node  The node to be added to the container.
+    // @return  True if the node was successfully added to the container. False
+    //          if the node was already in the contianer. On error state of node
+    //          is unchanged.
+    bool add(T& node) noexcept;
+
+    // removes the node from the lru and sets it previous and next to nullptr.
+    //
+    // @param node  The node to be removed from the container.
+    // @return  True if the node was successfully removed from the container.
+    //          False if the node was not part of the container. On error, the
+    //          state of node is unchanged.
+    bool remove(T& node) noexcept;
+
+    class LockedIterator;
+    // same as the above but uses an iterator context. The iterator is updated
+    // on removal of the corresponding node to point to the next node. The
+    // iterator context holds the lock on the lru.
+    //
+    // iterator will be advanced to the next node after removing the node
+    //
+    // @param it    Iterator that will be removed
+    void remove(LockedIterator& it) noexcept;
+
+    // replaces one node with another, at the same position
+    //
+    // @param oldNode   node being replaced
+    // @param newNode   node to replace oldNode with
+    //
+    // @return true  If the replace was successful. Returns false if the
+    //               destination node did not exist in the container, or if the
+    //               source node already existed.
+    bool replace(T& oldNode, T& newNode) noexcept;
+
+    // context for iterating the MM container. At any given point of time,
+    // there can be only one iterator active since we need to lock the LRU for
+    // iteration. we can support multiple iterators at same time, by using a
+    // shared ptr in the context for the lock holder in the future.
+    class LockedIterator {
+     public:
+      using ListIterator = typename LruList::DListIterator;
+      // noncopyable but movable.
+      LockedIterator(const LockedIterator&) = delete;
+      LockedIterator& operator=(const LockedIterator&) = delete;
+      LockedIterator(LockedIterator&&) noexcept = default;
+
+      LockedIterator& operator++() noexcept {
+        auto it = ++getIter();
+        skipAccessed(it);
+        return *this;
+      }
+
+      void skipAccessed(ListIterator& it) noexcept {
+        while (it) {
+          T& node = *it;
+          if (!Container<T, HookPtr>::isAccessed(node)) {
+            break; // found a valid eviction victim
+          }
+          ++it; // skip this accessed item
+        }
+      }
+
+      LockedIterator& operator--() {
+        throw std::invalid_argument(
+            "Decrementing eviction iterator is not supported");
+      }
+
+      T* operator->() const noexcept { return getIter().operator->(); }
+      T& operator*() const noexcept { return getIter().operator*(); }
+
+      bool operator==(const LockedIterator& other) const noexcept {
+        return &c_ == &other.c_ && tIter_ == other.tIter_ &&
+               mIter_ == other.mIter_;
+      }
+
+      bool operator!=(const LockedIterator& other) const noexcept {
+        return !(*this == other);
+      }
+
+      explicit operator bool() const noexcept { return tIter_ || mIter_; }
+
+      T* get() const noexcept { return getIter().get(); }
+
+      // Invalidates this iterator
+      void reset() noexcept {
+        // Point iterator to first list's rend
+        tIter_.reset();
+        mIter_.reset();
+      }
+
+      // 1. Invalidate this iterator
+      // 2. Unlock
+      void destroy() {
+        reset();
+        if (l_.owns_lock()) {
+          l_.unlock();
+        }
+      }
+
+      // Reset this iterator to the beginning
+      void resetToBegin() {
+        if (!l_.owns_lock()) {
+          l_.lock();
+        }
+        tIter_.resetToBegin();
+        mIter_.resetToBegin();
+      }
+
+     private:
+      // private because it's easy to misuse and cause deadlock for MMS3FIFO
+      LockedIterator& operator=(LockedIterator&&) noexcept = default;
+
+      // create an lru iterator with the lock being held.
+      explicit LockedIterator(LockHolder l,
+                              const Container<T, HookPtr>& c) noexcept;
+
+      const ListIterator& getIter() const noexcept {
+        return evictTiny() ? tIter_ : mIter_;
+      }
+
+      ListIterator& getIter() noexcept {
+        return const_cast<ListIterator&>(
+            static_cast<const LockedIterator*>(this)->getIter());
+      }
+
+      bool evictTiny() const noexcept {
+        if (!mIter_) {
+          return true;
+        }
+        if (!tIter_) {
+          return false;
+        }
+
+        const auto expectedSize =
+            c_.config_.tinySizePercent * c_.lru_.size() / 100;
+        auto isTinyBig = c_.lru_.getList(LruType::Tiny).size() > expectedSize;
+        return isTinyBig;
+      }
+
+      // only the container can create iterators
+      friend Container<T, HookPtr>;
+
+      const Container<T, HookPtr>& c_;
+      // Tiny and main cache iterators
+      ListIterator tIter_;
+      ListIterator mIter_;
+      // lock protecting the validity of the iterator
+      LockHolder l_;
+    };
+
+    Config getConfig() const;
+
+    void setConfig(const Config& newConfig);
+
+    void maybeResizeGhostLocked() noexcept;
+
+    bool isEmpty() const noexcept {
+      LockHolder l(lruMutex_);
+      return lru_.size() == 0;
+    }
+
+    size_t size() const noexcept {
+      LockHolder l(lruMutex_);
+      return lru_.size();
+    }
+
+    // Returns the eviction age stats. See CacheStats.h for details
+    EvictionAgeStat getEvictionAgeStat(uint64_t projectedLength) const noexcept;
+
+    // Obtain an iterator that start from the tail and can be used
+    // to search for evictions. This iterator holds a lock to this
+    // container and only one such iterator can exist at a time
+    LockedIterator getEvictionIterator() noexcept;
+
+    // Execute provided function under container lock. Function gets
+    // iterator passed as parameter.
+    template <typename F>
+    void withEvictionIterator(F&& f);
+
+    // Execute provided function under container lock.
+    template <typename F>
+    void withContainerLock(F&& f);
+
+    // for saving the state of the lru
+    //
+    // precondition:  serialization must happen without any reader or writer
+    // present. Any modification of this object afterwards will result in an
+    // invalid, inconsistent state for the serialized data.
+    //
+    serialization::MMS3FIFOObject saveState() const noexcept;
+
+    // return the stats for this container.
+    MMContainerStat getStats() const noexcept;
+
+    static LruType getLruType(const T& node) noexcept {
+      return isTiny(node) ? LruType::Tiny : LruType::Main;
+    }
+
+   private:
+    EvictionAgeStat getEvictionAgeStatLocked(
+        uint64_t projectedLength) const noexcept;
+
+    static Time getUpdateTime(const T& node) noexcept {
+      return (node.*HookPtr).getUpdateTime();
+    }
+
+    static void setUpdateTime(T& node, Time time) noexcept {
+      (node.*HookPtr).setUpdateTime(time);
+    }
+
+    // Returns the hash of node's key
+    static size_t hashNode64(const T& node) noexcept {
+      return folly::hasher<folly::StringPiece>()(node.getKey());
+    }
+    static uint32_t hashNode(const T& node) noexcept {
+      return static_cast<uint32_t>(
+          folly::hasher<folly::StringPiece>()(node.getKey()));
+    }
+
+    // remove node from lru and adjust insertion points
+    //
+    // @param node          node to remove
+    void removeLocked(T& node) noexcept;
+
+    static bool isTiny(const T& node) noexcept {
+      return node.template isFlagSet<RefFlags::kMMFlag0>();
+    }
+
+    static bool isAccessed(const T& node) noexcept {
+      return node.template isFlagSet<RefFlags::kMMFlag1>();
+    }
+
+    // Bit MM_BIT_0 is used to record if the item is in tiny cache.
+    static void markTiny(T& node) noexcept {
+      node.template setFlag<RefFlags::kMMFlag0>();
+    }
+    static void unmarkTiny(T& node) noexcept {
+      node.template unSetFlag<RefFlags::kMMFlag0>();
+    }
+
+    // Bit MM_BIT_1 is used to record if the item has been accessed since being
+    // written in cache. Unaccessed items are ignored when determining projected
+    // update time.
+    static void markAccessed(T& node) noexcept {
+      node.template setFlag<RefFlags::kMMFlag1>();
+    }
+    static void unmarkAccessed(T& node) noexcept {
+      node.template unSetFlag<RefFlags::kMMFlag1>();
+    }
+
+    void rebalanceForEviction();
+
+    mutable Mutex lruMutex_;
+
+    // the lru
+    LruList lru_;
+
+    // Current capacity to track ghost size
+    size_t capacity_{0};
+
+    facebook::cachelib::util::FIFOConcurrentHashSet32 ghostQueue_;
+
+    // Config for this lru.
+    // Write access to the MMS3FIFO Config is serialized.
+    // Reads may be racy.
+    Config config_{};
+
+    // FRIEND_TEST(MMTinyLFUTest, SegmentStress);
+    // FRIEND_TEST(MMTinyLFUTest, TinyLFUBasic);
+    // FRIEND_TEST(MMTinyLFUTest, Reconfigure);
+  };
+};
+
+/* Container Interface Implementation */
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+MMS3FIFO::Container<T, HookPtr>::Container(serialization::MMS3FIFOObject object,
+                                           PtrCompressor compressor)
+    : lru_(*object.lrus(), std::move(compressor)), config_(*object.config()) {}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+bool MMS3FIFO::Container<T, HookPtr>::recordAccess(T& node,
+                                                   AccessMode mode) noexcept {
+  if ((mode == AccessMode::kWrite && !config_.updateOnWrite) ||
+      (mode == AccessMode::kRead && !config_.updateOnRead)) {
+    return false;
+  }
+
+  const auto curr = static_cast<Time>(util::getCurrentTimeSec());
+  // check if the node is still being memory managed
+  if (node.isInMMContainer() && !isAccessed(node)) {
+    markAccessed(node);
+    setUpdateTime(node, curr);
+    return true;
+  }
+  return false;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+cachelib::EvictionAgeStat MMS3FIFO::Container<T, HookPtr>::getEvictionAgeStat(
+    uint64_t projectedLength) const noexcept {
+  LockHolder l(lruMutex_);
+  return getEvictionAgeStatLocked(projectedLength);
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+cachelib::EvictionAgeStat
+MMS3FIFO::Container<T, HookPtr>::getEvictionAgeStatLocked(
+    uint64_t projectedLength) const noexcept {
+  EvictionAgeStat stat;
+  const auto curr = static_cast<Time>(util::getCurrentTimeSec());
+
+  auto& list = lru_.getList(LruType::Main);
+  auto it = list.rbegin();
+  stat.warmQueueStat.oldestElementAge =
+      it != list.rend() ? curr - getUpdateTime(*it) : 0;
+  stat.warmQueueStat.size = list.size();
+  for (size_t numSeen = 0; numSeen < projectedLength && it != list.rend();
+       ++numSeen, ++it) {
+  }
+  stat.warmQueueStat.projectedAge = it != list.rend()
+                                        ? curr - getUpdateTime(*it)
+                                        : stat.warmQueueStat.oldestElementAge;
+  return stat;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+bool MMS3FIFO::Container<T, HookPtr>::add(T& node) noexcept {
+  const auto currTime = static_cast<Time>(util::getCurrentTimeSec());
+  auto ghostContains = ghostQueue_.contains(nodeHash);
+
+  LockHolder l(lruMutex_);
+  if (node.isInMMContainer()) {
+    return false;
+  }
+  unmarkAccessed(node);
+  setUpdateTime(node, currTime);
+
+  if (!ghostContains) {
+    auto& tinyLru = lru_.getList(LruType::Tiny);
+    tinyLru.linkAtHead(node);
+    markTiny(node);
+  } else {
+    // Insert to main queue
+    auto& mainLru = lru_.getList(LruType::Main);
+    mainLru.linkAtHead(node);
+  }
+
+
+  node.markInMMContainer();
+  return true;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+void MMS3FIFO::Container<T, HookPtr>::rebalanceForEviction() {
+  // Bulk move accessed items from tiny to main cache
+  // Until tinycache's tail is unaccessed or tiny cache is within size limit
+  // Room for optimization:
+  // We can bulk move segments to main instead of one by one
+  auto& tinyLru = lru_.getList(LruType::Tiny);
+  auto& mainLru = lru_.getList(LruType::Main);
+
+  bool isTinyTailUnaccessed = false;
+  const auto expectedSize = config_.tinySizePercent * lru_.size() / 100;
+  while (!isTinyTailUnaccessed) {
+    if (tinyLru.size() <= expectedSize) {
+      break;
+    }
+    auto tailNode = tinyLru.getTail();
+    if (tailNode == nullptr || !isAccessed(*tailNode)) {
+      isTinyTailUnaccessed = true;
+      break;
+    }
+    tinyLru.remove(*tailNode);
+
+    mainLru.linkAtHead(*tailNode);
+    unmarkTiny(*tailNode);
+    unmarkAccessed(*tailNode);
+  }
+
+  // Reinsert items in main cache to head, until main cache's tail is unaccessed
+  // TODO: Room for optimization:
+  // We can get the position of first unaccessed item from the tail
+  // And move the whole segment to head in one operation
+  bool isMainTailUnaccessed = false;
+  while (!isMainTailUnaccessed) {
+    auto tailNode = mainLru.getTail();
+    if (tailNode == nullptr || !isAccessed(*tailNode)) {
+      isMainTailUnaccessed = true;
+      break;
+    }
+    mainLru.remove(*tailNode);
+    mainLru.linkAtHead(*tailNode);
+    unmarkAccessed(*tailNode);
+  }
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+void MMS3FIFO::Container<T, HookPtr>::maybeResizeGhostLocked() noexcept {
+  size_t lruSize = lru_.size();
+
+  // Grow when size doubled, shrink when halved
+  const bool shouldGrow = lruSize >= 2 * capacity_;
+  const bool shouldShrink = lruSize <= capacity_ / 2;
+
+  if (!shouldGrow && !shouldShrink) {
+    return;
+  }
+
+  size_t expectedGhostSize =
+      static_cast<size_t>(lruSize * config_.ghostSizePercent / 100);
+  ghostQueue_.resize(expectedGhostSize);
+  capacity_ = lruSize;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+typename MMS3FIFO::Container<T, HookPtr>::LockedIterator
+MMS3FIFO::Container<T, HookPtr>::getEvictionIterator() noexcept {
+  LockHolder l(lruMutex_);
+  maybeResizeGhostLocked();
+  rebalanceForEviction();
+  return LockedIterator{std::move(l), *this};
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+template <typename F>
+void MMS3FIFO::Container<T, HookPtr>::withEvictionIterator(F&& fun) {
+  // uses spin lock which does not support combined locking
+  fun(getEvictionIterator());
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+template <typename F>
+void MMS3FIFO::Container<T, HookPtr>::withContainerLock(F&& fun) {
+  LockHolder l(lruMutex_);
+  fun();
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+void MMS3FIFO::Container<T, HookPtr>::removeLocked(T& node) noexcept {
+  if (isTiny(node)) {
+    lru_.getList(LruType::Tiny).remove(node);
+    unmarkTiny(node);
+    ghostQueue_.insert(hashNode(node));
+  } else {
+    lru_.getList(LruType::Main).remove(node);
+  }
+
+  unmarkAccessed(node);
+  node.unmarkInMMContainer();
+  return;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+bool MMS3FIFO::Container<T, HookPtr>::remove(T& node) noexcept {
+  LockHolder l(lruMutex_);
+  if (!node.isInMMContainer()) {
+    return false;
+  }
+  removeLocked(node);
+  return true;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+void MMS3FIFO::Container<T, HookPtr>::remove(LockedIterator& it) noexcept {
+  T& node = *it;
+  XDCHECK(node.isInMMContainer());
+  ++it;
+  removeLocked(node);
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+bool MMS3FIFO::Container<T, HookPtr>::replace(T& oldNode, T& newNode) noexcept {
+  LockHolder l(lruMutex_);
+  if (!oldNode.isInMMContainer() || newNode.isInMMContainer()) {
+    return false;
+  }
+  const auto updateTime = getUpdateTime(oldNode);
+
+  if (isTiny(oldNode)) {
+    lru_.getList(LruType::Tiny).replace(oldNode, newNode);
+    unmarkTiny(oldNode);
+    markTiny(newNode);
+  } else {
+    lru_.getList(LruType::Main).replace(oldNode, newNode);
+  }
+
+  oldNode.unmarkInMMContainer();
+  newNode.markInMMContainer();
+  setUpdateTime(newNode, updateTime);
+  if (isAccessed(oldNode)) {
+    markAccessed(newNode);
+  } else {
+    unmarkAccessed(newNode);
+  }
+  return true;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+typename MMS3FIFO::Config MMS3FIFO::Container<T, HookPtr>::getConfig() const {
+  LockHolder l(lruMutex_);
+  return config_;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+void MMS3FIFO::Container<T, HookPtr>::setConfig(const Config& c) {
+  LockHolder l(lruMutex_);
+  config_ = c;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+serialization::MMS3FIFOObject MMS3FIFO::Container<T, HookPtr>::saveState()
+    const noexcept {
+  serialization::MMS3FIFOConfig configObject;
+  *configObject.updateOnWrite() = config_.updateOnWrite;
+  *configObject.updateOnRead() = config_.updateOnRead;
+  *configObject.ghostSizePercent() = config_.ghostSizePercent;
+  *configObject.tinySizePercent() = config_.tinySizePercent;
+  // TODO: Serialize the ghost queue too.
+  serialization::MMS3FIFOObject object;
+  *object.config() = configObject;
+  *object.lrus() = lru_.saveState();
+  return object;
+}
+
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+MMContainerStat MMS3FIFO::Container<T, HookPtr>::getStats() const noexcept {
+  LockHolder l(lruMutex_);
+  auto* tail = lru_.size() == 0 ? nullptr : lru_.rbegin().get();
+  return {
+      lru_.size(), tail == nullptr ? 0 : getUpdateTime(*tail), 0, 0, 0, 0, 0};
+}
+
+// Locked Iterator Context Implementation
+template <typename T, MMS3FIFO::Hook<T> T::* HookPtr>
+MMS3FIFO::Container<T, HookPtr>::LockedIterator::LockedIterator(
+    LockHolder l, const Container<T, HookPtr>& c) noexcept
+    : c_(c),
+      tIter_(c.lru_.getList(LruType::Tiny).rbegin()),
+      mIter_(c.lru_.getList(LruType::Main).rbegin()),
+      l_(std::move(l)) {}
+} // namespace facebook::cachelib

--- a/cachelib/allocator/MMTinyLFU-v0.h
+++ b/cachelib/allocator/MMTinyLFU-v0.h
@@ -1,0 +1,916 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#include <folly/Format.h>
+#include <folly/Math.h>
+#pragma GCC diagnostic pop
+
+#include "cachelib/allocator/Cache.h"
+#include "cachelib/allocator/CacheStats.h"
+#include "cachelib/allocator/Util.h"
+#include "cachelib/allocator/datastruct/MultiDList.h"
+#include "cachelib/allocator/memory/serialize/gen-cpp2/objects_types.h"
+#include "cachelib/common/CompilerUtils.h"
+#include "cachelib/common/CountMinSketch.h"
+#include "cachelib/common/Mutex.h"
+
+namespace facebook::cachelib {
+// This version does deletions on mmtinylfu
+// to make it our template.
+class MMTinyLFU {
+ public:
+  // unique identifier per MMType
+  static const int kId;
+
+  // forward declaration;
+  template <typename T>
+  using Hook = DListHook<T>;
+  using SerializationType = serialization::MMTinyLFUObject;
+  using SerializationConfigType = serialization::MMTinyLFUConfig;
+  using SerializationTypeContainer = serialization::MMTinyLFUCollection;
+
+  enum LruType { Main, Tiny, NumTypes };
+
+  // Config class for MMTinfyLFU
+  struct Config {
+    // create from serialized config
+    explicit Config(SerializationConfigType configState)
+        : Config(*configState.lruRefreshTime(),
+                 *configState.lruRefreshRatio(),
+                 *configState.updateOnWrite(),
+                 *configState.updateOnRead(),
+                 *configState.tryLockUpdate(),
+                 *configState.windowToCacheSizeRatio(),
+                 *configState.tinySizePercent(),
+                 *configState.mmReconfigureIntervalSecs(),
+                 *configState.newcomerWinsOnTie()) {}
+
+    // @param time        the LRU refresh time in seconds.
+    //                    An item will be promoted only once in each lru refresh
+    //                    time depite the number of accesses it gets.
+    // @param udpateOnW   whether to promote the item on write
+    // @param updateOnR   whether to promote the item on read
+    Config(uint32_t time, bool updateOnW, bool updateOnR)
+        : Config(time,
+                 updateOnW,
+                 updateOnR,
+                 /* try lock update */ false,
+                 16,
+                 1) {}
+
+    // @param time              the LRU refresh time in seconds.
+    //                          An item will be promoted only once in each lru
+    //                          refresh time depite the number of accesses it
+    //                          gets.
+    // @param udpateOnW         whether to promote the item on write
+    // @param updateOnR         whether to promote the item on read
+    // @param windowToCacheSize multiplier of window size to cache size
+    // @param tinySizePct       percentage number of tiny size to overall size
+    Config(uint32_t time,
+           bool updateOnW,
+           bool updateOnR,
+           size_t windowToCacheSize,
+           size_t tinySizePct)
+        : Config(time,
+                 updateOnW,
+                 updateOnR,
+                 /* try lock update */ false,
+                 windowToCacheSize,
+                 tinySizePct) {}
+
+    // @param time              the LRU refresh time in seconds.
+    //                          An item will be promoted only once in each lru
+    //                          refresh time depite the number of accesses it
+    //                          gets.
+    // @param udpateOnW         whether to promote the item on write
+    // @param updateOnR         whether to promote the item on read
+    // @param tryLockU          whether to use a try lock when doing update.
+    // @param windowToCacheSize multiplier of window size to cache size
+    // @param tinySizePct       percentage number of tiny size to overall size
+    Config(uint32_t time,
+           bool updateOnW,
+           bool updateOnR,
+           bool tryLockU,
+           size_t windowToCacheSize,
+           size_t tinySizePct)
+        : Config(time,
+                 0.,
+                 updateOnW,
+                 updateOnR,
+                 tryLockU,
+                 windowToCacheSize,
+                 tinySizePct) {}
+
+    // @param time                    the LRU refresh time in seconds.
+    //                                An item will be promoted only once in each
+    //                                lru refresh time depite the number of
+    //                                accesses it gets.
+    // @param ratio                   the lru refresh ratio. The ratio times the
+    //                                oldest element's lifetime in warm queue
+    //                                would be the minimum value of LRU refresh
+    //                                time.
+    // @param udpateOnW               whether to promote the item on write
+    // @param updateOnR               whether to promote the item on read
+    // @param tryLockU                whether to use a try lock when doing
+    //                                update.
+    // @param windowToCacheSize       multiplier of window size to cache size
+    // @param tinySizePct             percentage number of tiny size to overall
+    //                                size
+    Config(uint32_t time,
+           double ratio,
+           bool updateOnW,
+           bool updateOnR,
+           bool tryLockU,
+           size_t windowToCacheSize,
+           size_t tinySizePct)
+        : Config(time,
+                 ratio,
+                 updateOnW,
+                 updateOnR,
+                 tryLockU,
+                 windowToCacheSize,
+                 tinySizePct,
+                 0) {}
+
+    // @param time                    the LRU refresh time in seconds.
+    //                                An item will be promoted only once in each
+    //                                lru refresh time depite the number of
+    //                                accesses it gets.
+    // @param ratio                   the lru refresh ratio. The ratio times the
+    //                                oldest element's lifetime in warm queue
+    //                                would be the minimum value of LRU refresh
+    //                                time.
+    // @param udpateOnW               whether to promote the item on write
+    // @param updateOnR               whether to promote the item on read
+    // @param tryLockU                whether to use a try lock when doing
+    //                                update.
+    // @param windowToCacheSize       multiplier of window size to cache size
+    // @param tinySizePct             percentage number of tiny size to overall
+    //                                size
+    // @param mmReconfigureInterval   Time interval for recalculating lru
+    //                                refresh time according to the ratio.
+    Config(uint32_t time,
+           double ratio,
+           bool updateOnW,
+           bool updateOnR,
+           bool tryLockU,
+           size_t windowToCacheSize,
+           size_t tinySizePct,
+           uint32_t mmReconfigureInterval)
+        : defaultLruRefreshTime(time),
+          lruRefreshRatio(ratio),
+          updateOnWrite(updateOnW),
+          updateOnRead(updateOnR),
+          tryLockUpdate(tryLockU),
+          windowToCacheSizeRatio(windowToCacheSize),
+          tinySizePercent(tinySizePct),
+          mmReconfigureIntervalSecs(
+              std::chrono::seconds(mmReconfigureInterval)) {
+      checkConfig();
+    }
+
+    // @param time                    the LRU refresh time in seconds.
+    //                                An item will be promoted only once in each
+    //                                lru refresh time depite the number of
+    //                                accesses it gets.
+    // @param ratio                   the lru refresh ratio. The ratio times the
+    //                                oldest element's lifetime in warm queue
+    //                                would be the minimum value of LRU refresh
+    //                                time.
+    // @param udpateOnW               whether to promote the item on write
+    // @param updateOnR               whether to promote the item on read
+    // @param tryLockU                whether to use a try lock when doing
+    //                                update.
+    // @param windowToCacheSize       multiplier of window size to cache size
+    // @param tinySizePct             percentage number of tiny size to overall
+    //                                size
+    // @param mmReconfigureInterval   Time interval for recalculating lru
+    //                                refresh time according to the ratio.
+    // @param newcomerWinsOnTie       If true, new comer will replace existing
+    //                                item if their access frequencies tie.
+    Config(uint32_t time,
+           double ratio,
+           bool updateOnW,
+           bool updateOnR,
+           bool tryLockU,
+           size_t windowToCacheSize,
+           size_t tinySizePct,
+           uint32_t mmReconfigureInterval,
+           bool _newcomerWinsOnTie)
+        : defaultLruRefreshTime(time),
+          lruRefreshRatio(ratio),
+          updateOnWrite(updateOnW),
+          updateOnRead(updateOnR),
+          tryLockUpdate(tryLockU),
+          windowToCacheSizeRatio(windowToCacheSize),
+          tinySizePercent(tinySizePct),
+          mmReconfigureIntervalSecs(
+              std::chrono::seconds(mmReconfigureInterval)),
+          newcomerWinsOnTie(_newcomerWinsOnTie) {
+      checkConfig();
+    }
+
+    Config() = default;
+    Config(const Config& rhs) = default;
+    Config(Config&& rhs) = default;
+
+    Config& operator=(const Config& rhs) = default;
+    Config& operator=(Config&& rhs) = default;
+
+    void checkConfig() {
+      if (tinySizePercent < 1 || tinySizePercent > 50) {
+        throw std::invalid_argument(
+            folly::sformat("Invalid tiny cache size {}. Tiny cache size "
+                           "must be between 1% and 50% of total cache size ",
+                           tinySizePercent));
+      }
+      if (windowToCacheSizeRatio < 2 || windowToCacheSizeRatio > 128) {
+        throw std::invalid_argument(
+            folly::sformat("Invalid window to cache size ratio {}. The ratio "
+                           "must be between 2 and 128",
+                           windowToCacheSizeRatio));
+      }
+    }
+
+    template <typename... Args>
+    void addExtraConfig(Args...) {}
+
+    // threshold value in seconds to compare with a node's update time to
+    // determine if we need to update the position of the node in the linked
+    // list. By default this is 60s to reduce the contention on the lru lock.
+    uint32_t defaultLruRefreshTime{60};
+    uint32_t lruRefreshTime{defaultLruRefreshTime};
+
+    // ratio of LRU refresh time to the tail age. If a refresh time computed
+    // according to this ratio is larger than lruRefreshtime, we will adopt
+    // this one instead of the lruRefreshTime set.
+    double lruRefreshRatio{0.};
+
+    // whether the lru needs to be updated on writes for recordAccess. If
+    // false, accessing the cache for writes does not promote the cached item
+    // to the head of the lru.
+    bool updateOnWrite{false};
+
+    // whether the lru needs to be updated on reads for recordAccess. If
+    // false, accessing the cache for reads does not promote the cached item
+    // to the head of the lru.
+    bool updateOnRead{true};
+
+    // whether to tryLock or lock the lru lock when attempting promotion on
+    // access. If set, and tryLock fails, access will not result in promotion.
+    bool tryLockUpdate{false};
+
+    // The multiplier for window size given the cache size.
+    size_t windowToCacheSizeRatio{32};
+
+    // The size of tiny cache, as a percentage of the total size.
+    size_t tinySizePercent{1};
+
+    // Minimum interval between reconfigurations. If 0, reconfigure is never
+    // called.
+    std::chrono::seconds mmReconfigureIntervalSecs{};
+
+    // If true, then if an item in the tail of the Tiny queue ties with the
+    // item in the tail of the main queue, the item from Tiny (newcomer) will
+    // replace the item from Main. This is fine for a default, but for
+    // strictly scan patterns (access a key exactly once and move on), this
+    // is not a desirable behavior (we'll always cache miss).
+    bool newcomerWinsOnTie{true};
+  };
+
+  // The container object which can be used to keep track of objects of type
+  // T. T must have a public member of type Hook. This object is wrapper
+  // around DList, is thread safe and can be accessed from multiple threads.
+  // The current implementation models an LRU using the above DList
+  // implementation.
+  template <typename T, Hook<T> T::* HookPtr>
+  struct Container {
+   private:
+    using LruList = MultiDList<T, HookPtr>;
+    using Mutex = folly::SpinLock;
+    using LockHolder = std::unique_lock<Mutex>;
+    using PtrCompressor = typename T::PtrCompressor;
+    using Time = typename Hook<T>::Time;
+    using CompressedPtrType = typename T::CompressedPtrType;
+    using RefFlags = typename T::Flags;
+
+   public:
+    Container() = default;
+    Container(Config c, PtrCompressor compressor)
+        : lru_(LruType::NumTypes, std::move(compressor)),
+          config_(std::move(c)) {
+      lruRefreshTime_ = config_.lruRefreshTime;
+      nextReconfigureTime_ =
+          config_.mmReconfigureIntervalSecs.count() == 0
+              ? std::numeric_limits<Time>::max()
+              : static_cast<Time>(util::getCurrentTimeSec()) +
+                    config_.mmReconfigureIntervalSecs.count();
+    }
+    Container(serialization::MMTinyLFUObject object, PtrCompressor compressor);
+
+    Container(const Container&) = delete;
+    Container& operator=(const Container&) = delete;
+
+    // records the information that the node was accessed. This could bump up
+    // the node to the head of the lru depending on the time when the node was
+    // last updated in lru and the kLruRefreshTime. If the node was moved to
+    // the head in the lru, the node's updateTime will be updated
+    // accordingly.
+    //
+    // @param node  node that we want to mark as relevant/accessed
+    // @param mode  the mode for the access operation.
+    //
+    // @return      True if the information is recorded and bumped the node
+    //              to the head of the lru, returns false otherwise
+    bool recordAccess(T& node, AccessMode mode) noexcept;
+
+    // adds the given node into the container and marks it as being present in
+    // the container. The node is added to the head of the lru.
+    //
+    // @param node  The node to be added to the container.
+    // @return  True if the node was successfully added to the container. False
+    //          if the node was already in the contianer. On error state of node
+    //          is unchanged.
+    bool add(T& node) noexcept;
+
+    // removes the node from the lru and sets it previous and next to nullptr.
+    //
+    // @param node  The node to be removed from the container.
+    // @return  True if the node was successfully removed from the container.
+    //          False if the node was not part of the container. On error, the
+    //          state of node is unchanged.
+    bool remove(T& node) noexcept;
+
+    class LockedIterator;
+    // same as the above but uses an iterator context. The iterator is updated
+    // on removal of the corresponding node to point to the next node. The
+    // iterator context holds the lock on the lru.
+    //
+    // iterator will be advanced to the next node after removing the node
+    //
+    // @param it    Iterator that will be removed
+    void remove(LockedIterator& it) noexcept;
+
+    // replaces one node with another, at the same position
+    //
+    // @param oldNode   node being replaced
+    // @param newNode   node to replace oldNode with
+    //
+    // @return true  If the replace was successful. Returns false if the
+    //               destination node did not exist in the container, or if the
+    //               source node already existed.
+    bool replace(T& oldNode, T& newNode) noexcept;
+
+    // context for iterating the MM container. At any given point of time,
+    // there can be only one iterator active since we need to lock the LRU for
+    // iteration. we can support multiple iterators at same time, by using a
+    // shared ptr in the context for the lock holder in the future.
+    class LockedIterator {
+     public:
+      using ListIterator = typename LruList::DListIterator;
+      // noncopyable but movable.
+      LockedIterator(const LockedIterator&) = delete;
+      LockedIterator& operator=(const LockedIterator&) = delete;
+      LockedIterator(LockedIterator&&) noexcept = default;
+
+      LockedIterator& operator++() noexcept {
+        ++getIter();
+        return *this;
+      }
+
+      LockedIterator& operator--() {
+        throw std::invalid_argument(
+            "Decrementing eviction iterator is not supported");
+      }
+
+      T* operator->() const noexcept { return getIter().operator->(); }
+      T& operator*() const noexcept { return getIter().operator*(); }
+
+      bool operator==(const LockedIterator& other) const noexcept {
+        return &c_ == &other.c_ && tIter_ == other.tIter_ &&
+               mIter_ == other.mIter_;
+      }
+
+      bool operator!=(const LockedIterator& other) const noexcept {
+        return !(*this == other);
+      }
+
+      explicit operator bool() const noexcept { return tIter_ || mIter_; }
+
+      T* get() const noexcept { return getIter().get(); }
+
+      // Invalidates this iterator
+      void reset() noexcept {
+        // Point iterator to first list's rend
+        tIter_.reset();
+        mIter_.reset();
+      }
+
+      // 1. Invalidate this iterator
+      // 2. Unlock
+      void destroy() {
+        reset();
+        if (l_.owns_lock()) {
+          l_.unlock();
+        }
+      }
+
+      // Reset this iterator to the beginning
+      void resetToBegin() {
+        if (!l_.owns_lock()) {
+          l_.lock();
+        }
+        tIter_.resetToBegin();
+        mIter_.resetToBegin();
+      }
+
+     private:
+      // private because it's easy to misuse and cause deadlock for MMTinyLFU
+      LockedIterator& operator=(LockedIterator&&) noexcept = default;
+
+      // create an lru iterator with the lock being held.
+      explicit LockedIterator(LockHolder l,
+                              const Container<T, HookPtr>& c) noexcept;
+
+      const ListIterator& getIter() const noexcept {
+        return evictTiny() ? tIter_ : mIter_;
+      }
+
+      ListIterator& getIter() noexcept {
+        return const_cast<ListIterator&>(
+            static_cast<const LockedIterator*>(this)->getIter());
+      }
+
+      bool evictTiny() const noexcept {
+        if (!mIter_) {
+          return true;
+        }
+        if (!tIter_) {
+          return false;
+        }
+        // Since iterators don't change the state of the container, we evict
+        // from tiny or main depending on whether the tiny node would be
+        // admitted to main cache. If it would be, we evict from main cache,
+        // otherwise tiny cache.
+        return !c_.admitToMain(*tIter_, *mIter_);
+      }
+
+      // only the container can create iterators
+      friend Container<T, HookPtr>;
+
+      const Container<T, HookPtr>& c_;
+      // Tiny and main cache iterators
+      ListIterator tIter_;
+      ListIterator mIter_;
+      // lock protecting the validity of the iterator
+      LockHolder l_;
+    };
+
+    Config getConfig() const;
+
+    void setConfig(const Config& newConfig);
+
+    bool isEmpty() const noexcept {
+      LockHolder l(lruMutex_);
+      return lru_.size() == 0;
+    }
+
+    size_t size() const noexcept {
+      LockHolder l(lruMutex_);
+      return lru_.size();
+    }
+
+    // reconfigure the MMContainer: update refresh time according to current
+    // tail age
+    void reconfigureLocked(const Time& currTime);
+
+    size_t counterSize() const noexcept {
+      LockHolder l(lruMutex_);
+      return accessFreq_.getByteSize();
+    }
+
+    // Returns the eviction age stats. See CacheStats.h for details
+    EvictionAgeStat getEvictionAgeStat(uint64_t projectedLength) const noexcept;
+
+    // Obtain an iterator that start from the tail and can be used
+    // to search for evictions. This iterator holds a lock to this
+    // container and only one such iterator can exist at a time
+    LockedIterator getEvictionIterator() const noexcept;
+
+    // Execute provided function under container lock. Function gets
+    // iterator passed as parameter.
+    template <typename F>
+    void withEvictionIterator(F&& f);
+
+    // Execute provided function under container lock.
+    template <typename F>
+    void withContainerLock(F&& f);
+
+    // for saving the state of the lru
+    //
+    // precondition:  serialization must happen without any reader or writer
+    // present. Any modification of this object afterwards will result in an
+    // invalid, inconsistent state for the serialized data.
+    //
+    serialization::MMTinyLFUObject saveState() const noexcept;
+
+    // return the stats for this container.
+    MMContainerStat getStats() const noexcept;
+
+    static LruType getLruType(const T& node) noexcept {
+      return isTiny(node) ? LruType::Tiny : LruType::Main;
+    }
+
+   private:
+    EvictionAgeStat getEvictionAgeStatLocked(
+        uint64_t projectedLength) const noexcept;
+
+    static Time getUpdateTime(const T& node) noexcept {
+      return (node.*HookPtr).getUpdateTime();
+    }
+
+    static void setUpdateTime(T& node, Time time) noexcept {
+      (node.*HookPtr).setUpdateTime(time);
+    }
+
+    // Returns the hash of node's key
+    static size_t hashNode(const T& node) noexcept {
+      return folly::hasher<folly::StringPiece>()(node.getKey());
+    }
+
+    // Returns true if tiny node must be admitted to main cache since its
+    // frequency is higher than that of the main node.
+    bool admitToMain(const T& tinyNode, const T& mainNode) const noexcept {
+      XDCHECK(isTiny(tinyNode));
+      XDCHECK(!isTiny(mainNode));
+      return true;
+    }
+
+    // remove node from lru and adjust insertion points
+    //
+    // @param node          node to remove
+    void removeLocked(T& node) noexcept;
+
+    static bool isTiny(const T& node) noexcept {
+      return node.template isFlagSet<RefFlags::kMMFlag0>();
+    }
+
+    static bool isAccessed(const T& node) noexcept {
+      return node.template isFlagSet<RefFlags::kMMFlag1>();
+    }
+
+    // Bit MM_BIT_0 is used to record if the item is in tiny cache.
+    static void markTiny(T& node) noexcept {
+      node.template setFlag<RefFlags::kMMFlag0>();
+    }
+    static void unmarkTiny(T& node) noexcept {
+      node.template unSetFlag<RefFlags::kMMFlag0>();
+    }
+
+    // Bit MM_BIT_1 is used to record if the item has been accessed since being
+    // written in cache. Unaccessed items are ignored when determining projected
+    // update time.
+    static void markAccessed(T& node) noexcept {
+      node.template setFlag<RefFlags::kMMFlag1>();
+    }
+    static void unmarkAccessed(T& node) noexcept {
+      node.template unSetFlag<RefFlags::kMMFlag1>();
+    }
+
+    // Initial cache capacity estimate for count-min-sketch
+    static constexpr size_t kDefaultCapacity = 100;
+
+    // Number of hashes
+    static constexpr size_t kHashCount = 4;
+
+    // The error threshold for frequency calculation
+    static constexpr size_t kErrorThreshold = 5;
+
+    // decay rate for frequency
+    static constexpr double kDecayFactor = 0.5;
+
+    // protects all operations on the lru. We never really just read the state
+    // of the LRU. Hence we dont really require a RW mutex at this point of
+    // time.
+    mutable Mutex lruMutex_;
+
+    // the lru
+    LruList lru_;
+
+    // the window size counter
+    size_t windowSize_{0};
+
+    // maximum value of window size which when hit the counters are halved
+    size_t maxWindowSize_{0};
+
+    // The capacity for which the counters are sized
+    size_t capacity_{0};
+
+    // The next time to reconfigure the container.
+    std::atomic<Time> nextReconfigureTime_{};
+
+    // How often to promote an item in the eviction queue.
+    std::atomic<uint32_t> lruRefreshTime_{};
+
+    // Max lruFreshTime.
+    static constexpr uint32_t kLruRefreshTimeCap{900};
+
+    // Config for this lru.
+    // Write access to the MMTinyLFU Config is serialized.
+    // Reads may be racy.
+    Config config_{};
+
+    // Approximate streaming frequency counters. The counts are halved every
+    // time the maxWindowSize is hit.
+    facebook::cachelib::util::CountMinSketch accessFreq_{};
+
+    FRIEND_TEST(MMTinyLFUTest, SegmentStress);
+    FRIEND_TEST(MMTinyLFUTest, TinyLFUBasic);
+    FRIEND_TEST(MMTinyLFUTest, Reconfigure);
+  };
+};
+
+/* Container Interface Implementation */
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+MMTinyLFU::Container<T, HookPtr>::Container(
+    serialization::MMTinyLFUObject object, PtrCompressor compressor)
+    : lru_(*object.lrus(), std::move(compressor)), config_(*object.config()) {
+  lruRefreshTime_ = config_.lruRefreshTime;
+  nextReconfigureTime_ = config_.mmReconfigureIntervalSecs.count() == 0
+                             ? std::numeric_limits<Time>::max()
+                             : static_cast<Time>(util::getCurrentTimeSec()) +
+                                   config_.mmReconfigureIntervalSecs.count();
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+bool MMTinyLFU::Container<T, HookPtr>::recordAccess(T& node,
+                                                    AccessMode mode) noexcept {
+  if ((mode == AccessMode::kWrite && !config_.updateOnWrite) ||
+      (mode == AccessMode::kRead && !config_.updateOnRead)) {
+    return false;
+  }
+
+  const auto curr = static_cast<Time>(util::getCurrentTimeSec());
+  // check if the node is still being memory managed
+  if (node.isInMMContainer() &&
+      ((curr >= getUpdateTime(node) +
+                    lruRefreshTime_.load(std::memory_order_relaxed)) ||
+       !isAccessed(node))) {
+    if (!isAccessed(node)) {
+      markAccessed(node);
+    }
+    LockHolder l(lruMutex_, std::defer_lock);
+    if (config_.tryLockUpdate) {
+      l.try_lock();
+    } else {
+      l.lock();
+    }
+    if (!l.owns_lock()) {
+      return false;
+    }
+    if (!node.isInMMContainer()) {
+      return false;
+    }
+
+    setUpdateTime(node, curr);
+    return true;
+  }
+  return false;
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+cachelib::EvictionAgeStat MMTinyLFU::Container<T, HookPtr>::getEvictionAgeStat(
+    uint64_t projectedLength) const noexcept {
+  LockHolder l(lruMutex_);
+  return getEvictionAgeStatLocked(projectedLength);
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+cachelib::EvictionAgeStat
+MMTinyLFU::Container<T, HookPtr>::getEvictionAgeStatLocked(
+    uint64_t projectedLength) const noexcept {
+  EvictionAgeStat stat;
+  const auto curr = static_cast<Time>(util::getCurrentTimeSec());
+
+  auto& list = lru_.getList(LruType::Main);
+  auto it = list.rbegin();
+  stat.warmQueueStat.oldestElementAge =
+      it != list.rend() ? curr - getUpdateTime(*it) : 0;
+  stat.warmQueueStat.size = list.size();
+  for (size_t numSeen = 0; numSeen < projectedLength && it != list.rend();
+       ++numSeen, ++it) {
+  }
+  stat.warmQueueStat.projectedAge = it != list.rend()
+                                        ? curr - getUpdateTime(*it)
+                                        : stat.warmQueueStat.oldestElementAge;
+  return stat;
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+bool MMTinyLFU::Container<T, HookPtr>::add(T& node) noexcept {
+  const auto currTime = static_cast<Time>(util::getCurrentTimeSec());
+  LockHolder l(lruMutex_);
+  if (node.isInMMContainer()) {
+    return false;
+  }
+
+  auto& tinyLru = lru_.getList(LruType::Tiny);
+  tinyLru.linkAtHead(node);
+  markTiny(node);
+
+  // If tiny cache is full, unconditionally promote tail to main cache.
+  const auto expectedSize = config_.tinySizePercent * lru_.size() / 100;
+  if (lru_.getList(LruType::Tiny).size() > expectedSize) {
+    auto tailNode = tinyLru.getTail();
+    tinyLru.remove(*tailNode);
+
+    auto& mainLru = lru_.getList(LruType::Main);
+    mainLru.linkAtHead(*tailNode);
+    unmarkTiny(*tailNode);
+  }
+
+  node.markInMMContainer();
+  setUpdateTime(node, currTime);
+  unmarkAccessed(node);
+  return true;
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+typename MMTinyLFU::Container<T, HookPtr>::LockedIterator
+MMTinyLFU::Container<T, HookPtr>::getEvictionIterator() const noexcept {
+  LockHolder l(lruMutex_);
+  return LockedIterator{std::move(l), *this};
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+template <typename F>
+void MMTinyLFU::Container<T, HookPtr>::withEvictionIterator(F&& fun) {
+  // TinyLFU uses spin lock which does not support combined locking
+  fun(getEvictionIterator());
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+template <typename F>
+void MMTinyLFU::Container<T, HookPtr>::withContainerLock(F&& fun) {
+  LockHolder l(lruMutex_);
+  fun();
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+void MMTinyLFU::Container<T, HookPtr>::removeLocked(T& node) noexcept {
+  if (isTiny(node)) {
+    lru_.getList(LruType::Tiny).remove(node);
+    unmarkTiny(node);
+  } else {
+    lru_.getList(LruType::Main).remove(node);
+  }
+
+  unmarkAccessed(node);
+  node.unmarkInMMContainer();
+  return;
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+bool MMTinyLFU::Container<T, HookPtr>::remove(T& node) noexcept {
+  LockHolder l(lruMutex_);
+  if (!node.isInMMContainer()) {
+    return false;
+  }
+  removeLocked(node);
+  return true;
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+void MMTinyLFU::Container<T, HookPtr>::remove(LockedIterator& it) noexcept {
+  T& node = *it;
+  XDCHECK(node.isInMMContainer());
+  ++it;
+  removeLocked(node);
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+bool MMTinyLFU::Container<T, HookPtr>::replace(T& oldNode,
+                                               T& newNode) noexcept {
+  LockHolder l(lruMutex_);
+  if (!oldNode.isInMMContainer() || newNode.isInMMContainer()) {
+    return false;
+  }
+  const auto updateTime = getUpdateTime(oldNode);
+
+  if (isTiny(oldNode)) {
+    lru_.getList(LruType::Tiny).replace(oldNode, newNode);
+    unmarkTiny(oldNode);
+    markTiny(newNode);
+  } else {
+    lru_.getList(LruType::Main).replace(oldNode, newNode);
+  }
+
+  oldNode.unmarkInMMContainer();
+  newNode.markInMMContainer();
+  setUpdateTime(newNode, updateTime);
+  if (isAccessed(oldNode)) {
+    markAccessed(newNode);
+  } else {
+    unmarkAccessed(newNode);
+  }
+  return true;
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+typename MMTinyLFU::Config MMTinyLFU::Container<T, HookPtr>::getConfig() const {
+  LockHolder l(lruMutex_);
+  return config_;
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+void MMTinyLFU::Container<T, HookPtr>::setConfig(const Config& c) {
+  LockHolder l(lruMutex_);
+  config_ = c;
+  lruRefreshTime_.store(config_.lruRefreshTime, std::memory_order_relaxed);
+  nextReconfigureTime_ = config_.mmReconfigureIntervalSecs.count() == 0
+                             ? std::numeric_limits<Time>::max()
+                             : static_cast<Time>(util::getCurrentTimeSec()) +
+                                   config_.mmReconfigureIntervalSecs.count();
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+serialization::MMTinyLFUObject MMTinyLFU::Container<T, HookPtr>::saveState()
+    const noexcept {
+  serialization::MMTinyLFUConfig configObject;
+  *configObject.lruRefreshTime() =
+      lruRefreshTime_.load(std::memory_order_relaxed);
+  *configObject.lruRefreshRatio() = config_.lruRefreshRatio;
+  *configObject.updateOnWrite() = config_.updateOnWrite;
+  *configObject.updateOnRead() = config_.updateOnRead;
+  *configObject.windowToCacheSizeRatio() = config_.windowToCacheSizeRatio;
+  *configObject.tinySizePercent() = config_.tinySizePercent;
+  *configObject.mmReconfigureIntervalSecs() =
+      config_.mmReconfigureIntervalSecs.count();
+  *configObject.newcomerWinsOnTie() = config_.newcomerWinsOnTie;
+  // TODO: May be save/restore the counters.
+
+  serialization::MMTinyLFUObject object;
+  *object.config() = configObject;
+  *object.lrus() = lru_.saveState();
+  return object;
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+MMContainerStat MMTinyLFU::Container<T, HookPtr>::getStats() const noexcept {
+  LockHolder l(lruMutex_);
+  auto* tail = lru_.size() == 0 ? nullptr : lru_.rbegin().get();
+  return {lru_.size(),
+          tail == nullptr ? 0 : getUpdateTime(*tail),
+          lruRefreshTime_.load(std::memory_order_relaxed),
+          0,
+          0,
+          0,
+          0};
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+void MMTinyLFU::Container<T, HookPtr>::reconfigureLocked(const Time& currTime) {
+  if (currTime < nextReconfigureTime_) {
+    return;
+  }
+  nextReconfigureTime_ = currTime + config_.mmReconfigureIntervalSecs.count();
+
+  // update LRU refresh time
+  auto stat = getEvictionAgeStatLocked(0);
+  auto lruRefreshTime = std::min(
+      std::max(config_.defaultLruRefreshTime,
+               static_cast<uint32_t>(stat.warmQueueStat.oldestElementAge *
+                                     config_.lruRefreshRatio)),
+      kLruRefreshTimeCap);
+
+  lruRefreshTime_.store(lruRefreshTime, std::memory_order_relaxed);
+}
+
+// Locked Iterator Context Implementation
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+MMTinyLFU::Container<T, HookPtr>::LockedIterator::LockedIterator(
+    LockHolder l, const Container<T, HookPtr>& c) noexcept
+    : c_(c),
+      tIter_(c.lru_.getList(LruType::Tiny).rbegin()),
+      mIter_(c.lru_.getList(LruType::Main).rbegin()),
+      l_(std::move(l)) {}
+} // namespace facebook::cachelib

--- a/cachelib/allocator/MMTinyLFU-v1.h
+++ b/cachelib/allocator/MMTinyLFU-v1.h
@@ -1,0 +1,847 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#include <folly/Format.h>
+#include <folly/Math.h>
+#pragma GCC diagnostic pop
+
+#include "cachelib/allocator/Cache.h"
+#include "cachelib/allocator/CacheStats.h"
+#include "cachelib/allocator/Util.h"
+#include "cachelib/allocator/datastruct/MultiDList.h"
+#include "cachelib/allocator/memory/serialize/gen-cpp2/objects_types.h"
+#include "cachelib/common/CompilerUtils.h"
+#include "cachelib/common/CountMinSketch.h"
+#include "cachelib/common/Mutex.h"
+
+namespace facebook::cachelib {
+// This version moves s3fifo_v0 to mmtinylfu template
+class MMTinyLFU {
+ public:
+  // unique identifier per MMType
+  static const int kId;
+
+  // forward declaration;
+  template <typename T>
+  using Hook = DListHook<T>;
+  using SerializationType = serialization::MMTinyLFUObject;
+  using SerializationConfigType = serialization::MMTinyLFUConfig;
+  using SerializationTypeContainer = serialization::MMTinyLFUCollection;
+
+  enum LruType { Main, Tiny, NumTypes };
+
+  // Config class for MMTinfyLFU
+  struct Config {
+    // create from serialized config
+    explicit Config(SerializationConfigType configState)
+        : Config(*configState.lruRefreshTime(),
+                 *configState.lruRefreshRatio(),
+                 *configState.updateOnWrite(),
+                 *configState.updateOnRead(),
+                 *configState.tryLockUpdate(),
+                 *configState.windowToCacheSizeRatio(),
+                 *configState.tinySizePercent(),
+                 *configState.mmReconfigureIntervalSecs(),
+                 *configState.newcomerWinsOnTie()) {}
+
+    // @param time        the LRU refresh time in seconds.
+    //                    An item will be promoted only once in each lru refresh
+    //                    time depite the number of accesses it gets.
+    // @param udpateOnW   whether to promote the item on write
+    // @param updateOnR   whether to promote the item on read
+    Config(uint32_t time, bool updateOnW, bool updateOnR)
+        : Config(time,
+                 updateOnW,
+                 updateOnR,
+                 /* try lock update */ false,
+                 16,
+                 1) {}
+
+    // @param time              the LRU refresh time in seconds.
+    //                          An item will be promoted only once in each lru
+    //                          refresh time depite the number of accesses it
+    //                          gets.
+    // @param udpateOnW         whether to promote the item on write
+    // @param updateOnR         whether to promote the item on read
+    // @param windowToCacheSize multiplier of window size to cache size
+    // @param tinySizePct       percentage number of tiny size to overall size
+    Config(uint32_t time,
+           bool updateOnW,
+           bool updateOnR,
+           size_t windowToCacheSize,
+           size_t tinySizePct)
+        : Config(time,
+                 updateOnW,
+                 updateOnR,
+                 /* try lock update */ false,
+                 windowToCacheSize,
+                 tinySizePct) {}
+
+    // @param time              the LRU refresh time in seconds.
+    //                          An item will be promoted only once in each lru
+    //                          refresh time depite the number of accesses it
+    //                          gets.
+    // @param udpateOnW         whether to promote the item on write
+    // @param updateOnR         whether to promote the item on read
+    // @param tryLockU          whether to use a try lock when doing update.
+    // @param windowToCacheSize multiplier of window size to cache size
+    // @param tinySizePct       percentage number of tiny size to overall size
+    Config(uint32_t time,
+           bool updateOnW,
+           bool updateOnR,
+           bool tryLockU,
+           size_t windowToCacheSize,
+           size_t tinySizePct)
+        : Config(time,
+                 0.,
+                 updateOnW,
+                 updateOnR,
+                 tryLockU,
+                 windowToCacheSize,
+                 tinySizePct) {}
+
+    // @param time                    the LRU refresh time in seconds.
+    //                                An item will be promoted only once in each
+    //                                lru refresh time depite the number of
+    //                                accesses it gets.
+    // @param ratio                   the lru refresh ratio. The ratio times the
+    //                                oldest element's lifetime in warm queue
+    //                                would be the minimum value of LRU refresh
+    //                                time.
+    // @param udpateOnW               whether to promote the item on write
+    // @param updateOnR               whether to promote the item on read
+    // @param tryLockU                whether to use a try lock when doing
+    //                                update.
+    // @param windowToCacheSize       multiplier of window size to cache size
+    // @param tinySizePct             percentage number of tiny size to overall
+    //                                size
+    Config(uint32_t time,
+           double ratio,
+           bool updateOnW,
+           bool updateOnR,
+           bool tryLockU,
+           size_t windowToCacheSize,
+           size_t tinySizePct)
+        : Config(time,
+                 ratio,
+                 updateOnW,
+                 updateOnR,
+                 tryLockU,
+                 windowToCacheSize,
+                 tinySizePct,
+                 0) {}
+
+    // @param time                    the LRU refresh time in seconds.
+    //                                An item will be promoted only once in each
+    //                                lru refresh time depite the number of
+    //                                accesses it gets.
+    // @param ratio                   the lru refresh ratio. The ratio times the
+    //                                oldest element's lifetime in warm queue
+    //                                would be the minimum value of LRU refresh
+    //                                time.
+    // @param udpateOnW               whether to promote the item on write
+    // @param updateOnR               whether to promote the item on read
+    // @param tryLockU                whether to use a try lock when doing
+    //                                update.
+    // @param windowToCacheSize       multiplier of window size to cache size
+    // @param tinySizePct             percentage number of tiny size to overall
+    //                                size
+    // @param mmReconfigureInterval   Time interval for recalculating lru
+    //                                refresh time according to the ratio.
+    Config(uint32_t time,
+           double ratio,
+           bool updateOnW,
+           bool updateOnR,
+           bool tryLockU,
+           size_t windowToCacheSize,
+           size_t tinySizePct,
+           uint32_t mmReconfigureInterval)
+        : defaultLruRefreshTime(time),
+          lruRefreshRatio(ratio),
+          updateOnWrite(updateOnW),
+          updateOnRead(updateOnR),
+          tryLockUpdate(tryLockU),
+          windowToCacheSizeRatio(windowToCacheSize),
+          tinySizePercent(tinySizePct),
+          mmReconfigureIntervalSecs(
+              std::chrono::seconds(mmReconfigureInterval)) {
+      checkConfig();
+    }
+
+    // @param time                    the LRU refresh time in seconds.
+    //                                An item will be promoted only once in each
+    //                                lru refresh time depite the number of
+    //                                accesses it gets.
+    // @param ratio                   the lru refresh ratio. The ratio times the
+    //                                oldest element's lifetime in warm queue
+    //                                would be the minimum value of LRU refresh
+    //                                time.
+    // @param udpateOnW               whether to promote the item on write
+    // @param updateOnR               whether to promote the item on read
+    // @param tryLockU                whether to use a try lock when doing
+    //                                update.
+    // @param windowToCacheSize       multiplier of window size to cache size
+    // @param tinySizePct             percentage number of tiny size to overall
+    //                                size
+    // @param mmReconfigureInterval   Time interval for recalculating lru
+    //                                refresh time according to the ratio.
+    // @param newcomerWinsOnTie       If true, new comer will replace existing
+    //                                item if their access frequencies tie.
+    Config(uint32_t time,
+           double ratio,
+           bool updateOnW,
+           bool updateOnR,
+           bool tryLockU,
+           size_t windowToCacheSize,
+           size_t tinySizePct,
+           uint32_t mmReconfigureInterval,
+           bool _newcomerWinsOnTie)
+        : defaultLruRefreshTime(time),
+          lruRefreshRatio(ratio),
+          updateOnWrite(updateOnW),
+          updateOnRead(updateOnR),
+          tryLockUpdate(tryLockU),
+          windowToCacheSizeRatio(windowToCacheSize),
+          tinySizePercent(tinySizePct),
+          mmReconfigureIntervalSecs(
+              std::chrono::seconds(mmReconfigureInterval)),
+          newcomerWinsOnTie(_newcomerWinsOnTie) {
+      checkConfig();
+    }
+
+    Config() = default;
+    Config(const Config& rhs) = default;
+    Config(Config&& rhs) = default;
+
+    Config& operator=(const Config& rhs) = default;
+    Config& operator=(Config&& rhs) = default;
+
+    void checkConfig() {
+      if (tinySizePercent < 1 || tinySizePercent > 50) {
+        throw std::invalid_argument(
+            folly::sformat("Invalid tiny cache size {}. Tiny cache size "
+                           "must be between 1% and 50% of total cache size ",
+                           tinySizePercent));
+      }
+      if (windowToCacheSizeRatio < 2 || windowToCacheSizeRatio > 128) {
+        throw std::invalid_argument(
+            folly::sformat("Invalid window to cache size ratio {}. The ratio "
+                           "must be between 2 and 128",
+                           windowToCacheSizeRatio));
+      }
+    }
+
+    template <typename... Args>
+    void addExtraConfig(Args...) {}
+
+    // threshold value in seconds to compare with a node's update time to
+    // determine if we need to update the position of the node in the linked
+    // list. By default this is 60s to reduce the contention on the lru lock.
+    uint32_t defaultLruRefreshTime{60};
+    uint32_t lruRefreshTime{defaultLruRefreshTime};
+
+    // ratio of LRU refresh time to the tail age. If a refresh time computed
+    // according to this ratio is larger than lruRefreshtime, we will adopt
+    // this one instead of the lruRefreshTime set.
+    double lruRefreshRatio{0.};
+
+    // whether the lru needs to be updated on writes for recordAccess. If
+    // false, accessing the cache for writes does not promote the cached item
+    // to the head of the lru.
+    bool updateOnWrite{false};
+
+    // whether the lru needs to be updated on reads for recordAccess. If
+    // false, accessing the cache for reads does not promote the cached item
+    // to the head of the lru.
+    bool updateOnRead{true};
+
+    // whether to tryLock or lock the lru lock when attempting promotion on
+    // access. If set, and tryLock fails, access will not result in promotion.
+    bool tryLockUpdate{false};
+
+    // The multiplier for window size given the cache size.
+    size_t windowToCacheSizeRatio{32};
+
+    // The size of tiny cache, as a percentage of the total size.
+    size_t tinySizePercent{1};
+
+    // Minimum interval between reconfigurations. If 0, reconfigure is never
+    // called.
+    std::chrono::seconds mmReconfigureIntervalSecs{};
+
+    // If true, then if an item in the tail of the Tiny queue ties with the
+    // item in the tail of the main queue, the item from Tiny (newcomer) will
+    // replace the item from Main. This is fine for a default, but for
+    // strictly scan patterns (access a key exactly once and move on), this
+    // is not a desirable behavior (we'll always cache miss).
+    bool newcomerWinsOnTie{true};
+  };
+
+  // The container object which can be used to keep track of objects of type
+  // T. T must have a public member of type Hook. This object is wrapper
+  // around DList, is thread safe and can be accessed from multiple threads.
+  // The current implementation models an LRU using the above DList
+  // implementation.
+  template <typename T, Hook<T> T::* HookPtr>
+  struct Container {
+   private:
+    using LruList = MultiDList<T, HookPtr>;
+    using Mutex = folly::SpinLock;
+    using LockHolder = std::unique_lock<Mutex>;
+    using PtrCompressor = typename T::PtrCompressor;
+    using Time = typename Hook<T>::Time;
+    using CompressedPtrType = typename T::CompressedPtrType;
+    using RefFlags = typename T::Flags;
+
+   public:
+    Container() = default;
+    Container(Config c, PtrCompressor compressor)
+        : lru_(LruType::NumTypes, std::move(compressor)),
+          config_(std::move(c)) {
+      lruRefreshTime_ = config_.lruRefreshTime;
+      nextReconfigureTime_ =
+          config_.mmReconfigureIntervalSecs.count() == 0
+              ? std::numeric_limits<Time>::max()
+              : static_cast<Time>(util::getCurrentTimeSec()) +
+                    config_.mmReconfigureIntervalSecs.count();
+    }
+    Container(serialization::MMTinyLFUObject object, PtrCompressor compressor);
+
+    Container(const Container&) = delete;
+    Container& operator=(const Container&) = delete;
+
+    // records the information that the node was accessed. This could bump up
+    // the node to the head of the lru depending on the time when the node was
+    // last updated in lru and the kLruRefreshTime. If the node was moved to
+    // the head in the lru, the node's updateTime will be updated
+    // accordingly.
+    //
+    // @param node  node that we want to mark as relevant/accessed
+    // @param mode  the mode for the access operation.
+    //
+    // @return      True if the information is recorded and bumped the node
+    //              to the head of the lru, returns false otherwise
+    bool recordAccess(T& node, AccessMode mode) noexcept;
+
+    // adds the given node into the container and marks it as being present in
+    // the container. The node is added to the head of the lru.
+    //
+    // @param node  The node to be added to the container.
+    // @return  True if the node was successfully added to the container. False
+    //          if the node was already in the contianer. On error state of node
+    //          is unchanged.
+    bool add(T& node) noexcept;
+
+    // removes the node from the lru and sets it previous and next to nullptr.
+    //
+    // @param node  The node to be removed from the container.
+    // @return  True if the node was successfully removed from the container.
+    //          False if the node was not part of the container. On error, the
+    //          state of node is unchanged.
+    bool remove(T& node) noexcept;
+
+    class LockedIterator;
+    // same as the above but uses an iterator context. The iterator is updated
+    // on removal of the corresponding node to point to the next node. The
+    // iterator context holds the lock on the lru.
+    //
+    // iterator will be advanced to the next node after removing the node
+    //
+    // @param it    Iterator that will be removed
+    void remove(LockedIterator& it) noexcept;
+
+    // replaces one node with another, at the same position
+    //
+    // @param oldNode   node being replaced
+    // @param newNode   node to replace oldNode with
+    //
+    // @return true  If the replace was successful. Returns false if the
+    //               destination node did not exist in the container, or if the
+    //               source node already existed.
+    bool replace(T& oldNode, T& newNode) noexcept;
+
+    // context for iterating the MM container. At any given point of time,
+    // there can be only one iterator active since we need to lock the LRU for
+    // iteration. we can support multiple iterators at same time, by using a
+    // shared ptr in the context for the lock holder in the future.
+    class LockedIterator {
+     public:
+      using ListIterator = typename LruList::DListIterator;
+      // noncopyable but movable.
+      LockedIterator(const LockedIterator&) = delete;
+      LockedIterator& operator=(const LockedIterator&) = delete;
+      LockedIterator(LockedIterator&&) noexcept = default;
+
+      LockedIterator& operator++() noexcept {
+        ++getIter();
+        return *this;
+      }
+
+      LockedIterator& operator--() {
+        throw std::invalid_argument(
+            "Decrementing eviction iterator is not supported");
+      }
+
+      T* operator->() const noexcept { return getIter().operator->(); }
+      T& operator*() const noexcept { return getIter().operator*(); }
+
+      bool operator==(const LockedIterator& other) const noexcept {
+        return &c_ == &other.c_ && tIter_ == other.tIter_ &&
+               mIter_ == other.mIter_;
+      }
+
+      bool operator!=(const LockedIterator& other) const noexcept {
+        return !(*this == other);
+      }
+
+      explicit operator bool() const noexcept { return tIter_ || mIter_; }
+
+      T* get() const noexcept { return getIter().get(); }
+
+      // Invalidates this iterator
+      void reset() noexcept {
+        // Point iterator to first list's rend
+        tIter_.reset();
+        mIter_.reset();
+      }
+
+      // 1. Invalidate this iterator
+      // 2. Unlock
+      void destroy() {
+        reset();
+        if (l_.owns_lock()) {
+          l_.unlock();
+        }
+      }
+
+      // Reset this iterator to the beginning
+      void resetToBegin() {
+        if (!l_.owns_lock()) {
+          l_.lock();
+        }
+        tIter_.resetToBegin();
+        mIter_.resetToBegin();
+      }
+
+     private:
+      // private because it's easy to misuse and cause deadlock for MMTinyLFU
+      LockedIterator& operator=(LockedIterator&&) noexcept = default;
+
+      // create an lru iterator with the lock being held.
+      explicit LockedIterator(LockHolder l,
+                              const Container<T, HookPtr>& c) noexcept;
+
+      const ListIterator& getIter() const noexcept {
+        return evictTiny() ? tIter_ : mIter_;
+      }
+
+      ListIterator& getIter() noexcept {
+        return const_cast<ListIterator&>(
+            static_cast<const LockedIterator*>(this)->getIter());
+      }
+
+      bool evictTiny() const noexcept {
+        if (!mIter_) {
+          return true;
+        }
+        if (!tIter_) {
+          return false;
+        }
+
+        const auto expectedSize =
+            c_.config_.tinySizePercent * c_.lru_.size() / 100;
+        auto isTinyBig = c_.lru_.getList(LruType::Tiny).size() > expectedSize;
+        return isTinyBig;
+      }
+
+      // only the container can create iterators
+      friend Container<T, HookPtr>;
+
+      const Container<T, HookPtr>& c_;
+      // Tiny and main cache iterators
+      ListIterator tIter_;
+      ListIterator mIter_;
+      // lock protecting the validity of the iterator
+      LockHolder l_;
+    };
+
+    Config getConfig() const;
+
+    void setConfig(const Config& newConfig);
+
+    bool isEmpty() const noexcept {
+      LockHolder l(lruMutex_);
+      return lru_.size() == 0;
+    }
+
+    size_t size() const noexcept {
+      LockHolder l(lruMutex_);
+      return lru_.size();
+    }
+
+    // reconfigure the MMContainer: update refresh time according to current
+    // tail age
+    void reconfigureLocked(const Time& currTime);
+
+    size_t counterSize() const noexcept {
+      LockHolder l(lruMutex_);
+      return accessFreq_.getByteSize();
+    }
+
+    // Returns the eviction age stats. See CacheStats.h for details
+    EvictionAgeStat getEvictionAgeStat(uint64_t projectedLength) const noexcept;
+
+    // Obtain an iterator that start from the tail and can be used
+    // to search for evictions. This iterator holds a lock to this
+    // container and only one such iterator can exist at a time
+    LockedIterator getEvictionIterator() const noexcept;
+
+    // Execute provided function under container lock. Function gets
+    // iterator passed as parameter.
+    template <typename F>
+    void withEvictionIterator(F&& f);
+
+    // Execute provided function under container lock.
+    template <typename F>
+    void withContainerLock(F&& f);
+
+    // for saving the state of the lru
+    //
+    // precondition:  serialization must happen without any reader or writer
+    // present. Any modification of this object afterwards will result in an
+    // invalid, inconsistent state for the serialized data.
+    //
+    serialization::MMTinyLFUObject saveState() const noexcept;
+
+    // return the stats for this container.
+    MMContainerStat getStats() const noexcept;
+
+    static LruType getLruType(const T& node) noexcept {
+      return isTiny(node) ? LruType::Tiny : LruType::Main;
+    }
+
+    // the lru
+    LruList lru_;
+
+   private:
+    EvictionAgeStat getEvictionAgeStatLocked(
+        uint64_t projectedLength) const noexcept;
+
+    static Time getUpdateTime(const T& node) noexcept {
+      return (node.*HookPtr).getUpdateTime();
+    }
+
+    static void setUpdateTime(T& node, Time time) noexcept {
+      (node.*HookPtr).setUpdateTime(time);
+    }
+
+    // Returns the hash of node's key
+    static size_t hashNode(const T& node) noexcept {
+      return folly::hasher<folly::StringPiece>()(node.getKey());
+    }
+
+    // remove node from lru and adjust insertion points
+    //
+    // @param node          node to remove
+    void removeLocked(T& node) noexcept;
+
+    static bool isTiny(const T& node) noexcept {
+      return node.template isFlagSet<RefFlags::kMMFlag0>();
+    }
+
+    static bool isAccessed(const T& node) noexcept {
+      return node.template isFlagSet<RefFlags::kMMFlag1>();
+    }
+
+    // Bit MM_BIT_0 is used to record if the item is in tiny cache.
+    static void markTiny(T& node) noexcept {
+      node.template setFlag<RefFlags::kMMFlag0>();
+    }
+    static void unmarkTiny(T& node) noexcept {
+      node.template unSetFlag<RefFlags::kMMFlag0>();
+    }
+
+    // Bit MM_BIT_1 is used to record if the item has been accessed since being
+    // written in cache. Unaccessed items are ignored when determining projected
+    // update time.
+    static void markAccessed(T& node) noexcept {
+      node.template setFlag<RefFlags::kMMFlag1>();
+    }
+    static void unmarkAccessed(T& node) noexcept {
+      node.template unSetFlag<RefFlags::kMMFlag1>();
+    }
+
+    // Initial cache capacity estimate for count-min-sketch
+    static constexpr size_t kDefaultCapacity = 100;
+
+    // Number of hashes
+    static constexpr size_t kHashCount = 4;
+
+    // The error threshold for frequency calculation
+    static constexpr size_t kErrorThreshold = 5;
+
+    // decay rate for frequency
+    static constexpr double kDecayFactor = 0.5;
+
+    // protects all operations on the lru. We never really just read the state
+    // of the LRU. Hence we dont really require a RW mutex at this point of
+    // time.
+    mutable Mutex lruMutex_;
+
+    // the window size counter
+    size_t windowSize_{0};
+
+    // maximum value of window size which when hit the counters are halved
+    size_t maxWindowSize_{0};
+
+    // The capacity for which the counters are sized
+    size_t capacity_{0};
+
+    // The next time to reconfigure the container.
+    std::atomic<Time> nextReconfigureTime_{};
+
+    // How often to promote an item in the eviction queue.
+    std::atomic<uint32_t> lruRefreshTime_{};
+
+    // Max lruFreshTime.
+    static constexpr uint32_t kLruRefreshTimeCap{900};
+
+    // Config for this lru.
+    // Write access to the MMTinyLFU Config is serialized.
+    // Reads may be racy.
+    Config config_{};
+
+    // Approximate streaming frequency counters. The counts are halved every
+    // time the maxWindowSize is hit.
+    facebook::cachelib::util::CountMinSketch accessFreq_{};
+
+    FRIEND_TEST(MMTinyLFUTest, SegmentStress);
+    FRIEND_TEST(MMTinyLFUTest, TinyLFUBasic);
+    FRIEND_TEST(MMTinyLFUTest, Reconfigure);
+  };
+};
+
+/* Container Interface Implementation */
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+MMTinyLFU::Container<T, HookPtr>::Container(
+    serialization::MMTinyLFUObject object, PtrCompressor compressor)
+    : lru_(*object.lrus(), std::move(compressor)), config_(*object.config()) {}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+bool MMTinyLFU::Container<T, HookPtr>::recordAccess(T& node,
+                                                    AccessMode mode) noexcept {
+  if ((mode == AccessMode::kWrite && !config_.updateOnWrite) ||
+      (mode == AccessMode::kRead && !config_.updateOnRead)) {
+    return false;
+  }
+
+  const auto curr = static_cast<Time>(util::getCurrentTimeSec());
+  // check if the node is still being memory managed
+  if (node.isInMMContainer() && !isAccessed(node)) {
+    markAccessed(node);
+    setUpdateTime(node, curr);
+    return true;
+  }
+  return false;
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+cachelib::EvictionAgeStat MMTinyLFU::Container<T, HookPtr>::getEvictionAgeStat(
+    uint64_t projectedLength) const noexcept {
+  LockHolder l(lruMutex_);
+  return getEvictionAgeStatLocked(projectedLength);
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+cachelib::EvictionAgeStat
+MMTinyLFU::Container<T, HookPtr>::getEvictionAgeStatLocked(
+    uint64_t projectedLength) const noexcept {
+  EvictionAgeStat stat;
+  const auto curr = static_cast<Time>(util::getCurrentTimeSec());
+
+  auto& list = lru_.getList(LruType::Main);
+  auto it = list.rbegin();
+  stat.warmQueueStat.oldestElementAge =
+      it != list.rend() ? curr - getUpdateTime(*it) : 0;
+  stat.warmQueueStat.size = list.size();
+  for (size_t numSeen = 0; numSeen < projectedLength && it != list.rend();
+       ++numSeen, ++it) {
+  }
+  stat.warmQueueStat.projectedAge = it != list.rend()
+                                        ? curr - getUpdateTime(*it)
+                                        : stat.warmQueueStat.oldestElementAge;
+  return stat;
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+bool MMTinyLFU::Container<T, HookPtr>::add(T& node) noexcept {
+  const auto currTime = static_cast<Time>(util::getCurrentTimeSec());
+  LockHolder l(lruMutex_);
+  if (node.isInMMContainer()) {
+    return false;
+  }
+
+  auto& tinyLru = lru_.getList(LruType::Tiny);
+  tinyLru.linkAtHead(node);
+  markTiny(node);
+
+  // If tiny cache is full, unconditionally promote tail to main cache.
+  const auto expectedSize = config_.tinySizePercent * lru_.size() / 100;
+  if (lru_.getList(LruType::Tiny).size() > expectedSize) {
+    auto tailNode = tinyLru.getTail();
+    tinyLru.remove(*tailNode);
+
+    auto& mainLru = lru_.getList(LruType::Main);
+    mainLru.linkAtHead(*tailNode);
+    unmarkTiny(*tailNode);
+  }
+
+  node.markInMMContainer();
+  setUpdateTime(node, currTime);
+  unmarkAccessed(node);
+  return true;
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+typename MMTinyLFU::Container<T, HookPtr>::LockedIterator
+MMTinyLFU::Container<T, HookPtr>::getEvictionIterator() const noexcept {
+  LockHolder l(lruMutex_);
+  return LockedIterator{std::move(l), *this};
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+template <typename F>
+void MMTinyLFU::Container<T, HookPtr>::withEvictionIterator(F&& fun) {
+  // uses spin lock which does not support combined locking
+  fun(getEvictionIterator());
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+template <typename F>
+void MMTinyLFU::Container<T, HookPtr>::withContainerLock(F&& fun) {
+  LockHolder l(lruMutex_);
+  fun();
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+void MMTinyLFU::Container<T, HookPtr>::removeLocked(T& node) noexcept {
+  if (isTiny(node)) {
+    lru_.getList(LruType::Tiny).remove(node);
+    unmarkTiny(node);
+  } else {
+    lru_.getList(LruType::Main).remove(node);
+  }
+
+  unmarkAccessed(node);
+  node.unmarkInMMContainer();
+  return;
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+bool MMTinyLFU::Container<T, HookPtr>::remove(T& node) noexcept {
+  LockHolder l(lruMutex_);
+  if (!node.isInMMContainer()) {
+    return false;
+  }
+  removeLocked(node);
+  return true;
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+void MMTinyLFU::Container<T, HookPtr>::remove(LockedIterator& it) noexcept {
+  T& node = *it;
+  XDCHECK(node.isInMMContainer());
+  ++it;
+  removeLocked(node);
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+bool MMTinyLFU::Container<T, HookPtr>::replace(T& oldNode,
+                                               T& newNode) noexcept {
+  LockHolder l(lruMutex_);
+  if (!oldNode.isInMMContainer() || newNode.isInMMContainer()) {
+    return false;
+  }
+  const auto updateTime = getUpdateTime(oldNode);
+
+  if (isTiny(oldNode)) {
+    lru_.getList(LruType::Tiny).replace(oldNode, newNode);
+    unmarkTiny(oldNode);
+    markTiny(newNode);
+  } else {
+    lru_.getList(LruType::Main).replace(oldNode, newNode);
+  }
+
+  oldNode.unmarkInMMContainer();
+  newNode.markInMMContainer();
+  setUpdateTime(newNode, updateTime);
+  if (isAccessed(oldNode)) {
+    markAccessed(newNode);
+  } else {
+    unmarkAccessed(newNode);
+  }
+  return true;
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+typename MMTinyLFU::Config MMTinyLFU::Container<T, HookPtr>::getConfig() const {
+  LockHolder l(lruMutex_);
+  return config_;
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+void MMTinyLFU::Container<T, HookPtr>::setConfig(const Config& c) {
+  LockHolder l(lruMutex_);
+  config_ = c;
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+serialization::MMTinyLFUObject MMTinyLFU::Container<T, HookPtr>::saveState()
+    const noexcept {
+  serialization::MMTinyLFUConfig configObject;
+  *configObject.updateOnWrite() = config_.updateOnWrite;
+  *configObject.updateOnRead() = config_.updateOnRead;
+  *configObject.tinySizePercent() = config_.tinySizePercent;
+  // TODO: Serialize the ghost queue too.
+  serialization::MMTinyLFUObject object;
+  *object.config() = configObject;
+  *object.lrus() = lru_.saveState();
+  return object;
+}
+
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+MMContainerStat MMTinyLFU::Container<T, HookPtr>::getStats() const noexcept {
+  LockHolder l(lruMutex_);
+  auto* tail = lru_.size() == 0 ? nullptr : lru_.rbegin().get();
+  return {
+      lru_.size(), tail == nullptr ? 0 : getUpdateTime(*tail), 0, 0, 0, 0, 0};
+}
+
+// Locked Iterator Context Implementation
+template <typename T, MMTinyLFU::Hook<T> T::* HookPtr>
+MMTinyLFU::Container<T, HookPtr>::LockedIterator::LockedIterator(
+    LockHolder l, const Container<T, HookPtr>& c) noexcept
+    : c_(c),
+      tIter_(c.lru_.getList(LruType::Tiny).rbegin()),
+      mIter_(c.lru_.getList(LruType::Main).rbegin()),
+      l_(std::move(l)) {}
+} // namespace facebook::cachelib

--- a/cachelib/allocator/serialize/objects.thrift
+++ b/cachelib/allocator/serialize/objects.thrift
@@ -109,6 +109,37 @@ struct MM2QCollection {
   1: required map<i32, map<i32, MM2QObject>> pools;
 }
 
+
+
+struct MMS3FIFOConfig {
+  1: required i32 lruRefreshTime;
+  2: required bool updateOnWrite;
+  3: required i32 windowToCacheSizeRatio;
+  4: required i32 tinySizePercent;
+  5: bool updateOnRead = true;
+  6: bool tryLockUpdate = false;
+  7: double lruRefreshRatio = 0.0;
+  8: i32 mmReconfigureIntervalSecs = 0;
+  9: bool newcomerWinsOnTie = true;
+  10: i32 protectionFreq_ = 3;
+  11: i32 protectionSegmentSizePct = 80;
+}
+
+struct MMS3FIFOObject {
+  1: required MMS3FIFOConfig config;
+
+  // number of evictions for this MM object.
+  2: i64 evictions = 0;
+
+  // Warm, hot and cold lrus
+  3: required MultiDListObject lrus;
+}
+
+struct MMS3FIFOCollection {
+  1: required map<i32, map<i32, MMS3FIFOObject>> pools;
+}
+
+
 struct MMTinyLFUConfig {
   1: required i32 lruRefreshTime;
   2: required bool updateOnWrite;

--- a/cachelib/allocator/serialize/objects.thrift
+++ b/cachelib/allocator/serialize/objects.thrift
@@ -112,17 +112,10 @@ struct MM2QCollection {
 
 
 struct MMS3FIFOConfig {
-  1: required i32 lruRefreshTime;
-  2: required bool updateOnWrite;
-  3: required i32 windowToCacheSizeRatio;
-  4: required i32 tinySizePercent;
-  5: bool updateOnRead = true;
-  6: bool tryLockUpdate = false;
-  7: double lruRefreshRatio = 0.0;
-  8: i32 mmReconfigureIntervalSecs = 0;
-  9: bool newcomerWinsOnTie = true;
-  10: i32 protectionFreq_ = 3;
-  11: i32 protectionSegmentSizePct = 80;
+  1: required bool updateOnWrite;
+  2: bool updateOnRead = true;
+  3: i32 tinySizePercent;
+  4: i32 ghostSizePercent;
 }
 
 struct MMS3FIFOObject {

--- a/cachelib/cachebench/cache/Cache.h
+++ b/cachelib/cachebench/cache/Cache.h
@@ -489,6 +489,23 @@ inline typename Lru2QAllocator::MMConfig makeMMConfig(
                                   config.useCombinedLockForIterators);
 }
 
+template <>
+inline typename S3FIFOAllocator::MMConfig makeMMConfig(
+    CacheConfig const& config) {
+       return S3FIFOAllocator::MMConfig(
+          config.lruUpdateOnWrite,
+          config.lruUpdateOnRead,
+          config.tinySizePercent,
+          config.ghostSizePercent);
+}
+
+template <>
+inline typename TinyLFUAllocator::MMConfig makeMMConfig(
+    CacheConfig const& config) {
+  return TinyLFUAllocator::MMConfig(
+      config.lruRefreshSec, config.lruUpdateOnWrite, config.lruUpdateOnRead);
+}
+
 template <typename Allocator>
 uint64_t Cache<Allocator>::fetchNandWrites() const {
   size_t total = 0;

--- a/cachelib/cachebench/runner/Stressor.cpp
+++ b/cachelib/cachebench/runner/Stressor.cpp
@@ -203,6 +203,12 @@ std::unique_ptr<Stressor> Stressor::makeStressor(
     } else if (cacheConfig.allocator == "LRU5B2Q") {
       return std::make_unique<AsyncCacheStressor<Lru5B2QAllocator>>(
           cacheConfig, stressorConfig, std::move(generator));
+    } else if (cacheConfig.allocator == "S3FIFO") {
+    return std::make_unique<CacheStressor<S3FIFOAllocator>>(
+        cacheConfig, stressorConfig, std::move(generator));
+    } else if (cacheConfig.allocator == "TinyLFU") {
+      return std::make_unique<CacheStressor<TinyLFUAllocator>>(
+          cacheConfig, stressorConfig, std::move(generator));
     }
   } else {
     auto generator = makeGenerator(stressorConfig);
@@ -218,6 +224,12 @@ std::unique_ptr<Stressor> Stressor::makeStressor(
           cacheConfig, stressorConfig, std::move(generator));
     } else if (cacheConfig.allocator == "LRU5B2Q") {
       return std::make_unique<CacheStressor<Lru5B2QAllocator>>(
+          cacheConfig, stressorConfig, std::move(generator));
+    } else if (cacheConfig.allocator == "S3FIFO") {
+      return std::make_unique<CacheStressor<S3FIFOAllocator>>(
+          cacheConfig, stressorConfig, std::move(generator));
+    }  else if (cacheConfig.allocator == "TinyLFU") {
+      return std::make_unique<CacheStressor<TinyLFUAllocator>>(
           cacheConfig, stressorConfig, std::move(generator));
     }
   }

--- a/cachelib/cachebench/util/CacheConfig.cpp
+++ b/cachelib/cachebench/util/CacheConfig.cpp
@@ -48,6 +48,9 @@ CacheConfig::CacheConfig(const folly::dynamic& configJson) {
   JSONSetVal(configJson, lru2qHotPct);
   JSONSetVal(configJson, lru2qColdPct);
 
+  JSONSetVal(configJson, ghostSizePercent);
+  JSONSetVal(configJson, tinySizePercent);
+
   JSONSetVal(configJson, allocFactor);
   JSONSetVal(configJson, maxAllocSize);
   JSONSetVal(configJson, minAllocSize);
@@ -112,7 +115,7 @@ CacheConfig::CacheConfig(const folly::dynamic& configJson) {
   // if you added new fields to the configuration, update the JSONSetVal
   // to make them available for the json configs and increment the size
   // below
-  checkCorrectSize<CacheConfig, 760>();
+  checkCorrectSize<CacheConfig, 776>();
 
   if (numPools != poolSizes.size()) {
     throw std::invalid_argument(folly::sformat(

--- a/cachelib/cachebench/util/CacheConfig.h
+++ b/cachelib/cachebench/util/CacheConfig.h
@@ -41,6 +41,8 @@ class CacheMonitorFactory {
   virtual std::unique_ptr<CacheMonitor> create(Lru2QAllocator& cache) = 0;
   virtual std::unique_ptr<CacheMonitor> create(Lru5BAllocator& cache) = 0;
   virtual std::unique_ptr<CacheMonitor> create(Lru5B2QAllocator& cache) = 0;
+  virtual std::unique_ptr<CacheMonitor> create(S3FIFOAllocator& cache) = 0;
+  virtual std::unique_ptr<CacheMonitor> create(TinyLFUAllocator& cache) = 0;
 };
 
 // Parse memory tiers configuration from JSON config
@@ -102,6 +104,10 @@ struct CacheConfig : public JSONConfig {
   // 2Q params
   size_t lru2qHotPct{20};
   size_t lru2qColdPct{20};
+
+  // S3FIFO params
+  size_t ghostSizePercent{100};
+  size_t tinySizePercent{10};
 
   double allocFactor{1.5};
   // maximum alloc size generated using the alloc factor above.

--- a/cachelib/cachebench/util/CacheConfig.h
+++ b/cachelib/cachebench/util/CacheConfig.h
@@ -106,8 +106,8 @@ struct CacheConfig : public JSONConfig {
   size_t lru2qColdPct{20};
 
   // S3FIFO params
-  size_t ghostSizePercent{100};
-  size_t tinySizePercent{10};
+  size_t ghostSizePercent{90}; // Ghost size as percentage of whole cache
+  size_t tinySizePercent{10}; // Tiny size as percentage of whole cache
 
   double allocFactor{1.5};
   // maximum alloc size generated using the alloc factor above.

--- a/cachelib/common/FIFOConcurrentHashSet.h
+++ b/cachelib/common/FIFOConcurrentHashSet.h
@@ -1,0 +1,70 @@
+
+#pragma once
+#include <folly/concurrency/ConcurrentHashMap.h>
+
+#include <atomic>
+#include <deque>
+#include <mutex>
+
+namespace facebook::cachelib::util {
+namespace detail {
+
+template <typename KeyT = uint32_t>
+class FIFOConcurrentHashSetBase {
+ public:
+  using Key = KeyT; // hashed object id
+  using TS = uint64_t;  // logical time / FIFO order
+
+  explicit FIFOConcurrentHashSetBase(size_t capacity)
+      : ghost_(capacity), seq_(0), queueSize_(0) {}
+
+  FIFOConcurrentHashSetBase() : seq_(0), queueSize_(0) {}
+
+  struct PendingEntry {
+    Key k;
+    TS ts;
+  };
+
+  inline void insert(Key k) {
+    TS ts = seq_.fetch_add(1, std::memory_order_relaxed);
+    ghost_.insert_or_assign(k, ts);
+    // If it overflows and wraps around, we reset the entire structure.
+    if (UNLIKELY(ts == std::numeric_limits<TS>::max())) {
+      ghost_.clear();
+    }
+  }
+
+  inline bool contains(Key k)  {
+    auto it = ghost_.find(k);
+    if (it == ghost_.end())
+      return false;
+    // Seq - current must be larger
+    auto currDiff = seq_.load(std::memory_order_relaxed) - it->second;
+    auto isValid = currDiff <= queueSize_.load(std::memory_order_relaxed);
+
+    if (!isValid) {
+      // remove stale entry
+      ghost_.erase(k);
+    }
+
+    return isValid;
+  }
+
+  inline void resize(TS limitTS) {
+    queueSize_.store(limitTS, std::memory_order_relaxed);
+  }
+
+ private:
+  folly::ConcurrentHashMap<Key, TS> ghost_;
+
+  // Logical TS counter
+  std::atomic<TS> seq_;
+  // Maximum size of the FIFO queue
+  std::atomic<TS> queueSize_;
+};
+
+} // namespace detail
+using FIFOConcurrentHashSet32 = detail::FIFOConcurrentHashSetBase<uint32_t>;
+using FIFOConcurrentHashSet64 = detail::FIFOConcurrentHashSetBase<uint64_t>;
+  
+} // namespace facebook::cachelib::util

--- a/cachelib/common/FIFOHashSet.h
+++ b/cachelib/common/FIFOHashSet.h
@@ -1,11 +1,8 @@
-/*
- * Copyright (c) Meta Platforms, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * ...
- */
-
 #pragma once
+
+#include <folly/Format.h>
+#include <folly/Math.h>
+#include <folly/container/F14Set.h>
 
 #include <cstdint>
 #include <deque>
@@ -13,27 +10,11 @@
 #include <unordered_set>
 
 namespace facebook::cachelib::util {
-
 namespace detail {
 
-// A bounded FIFO ghost list with O(1) membership check using a hash set.
-// Used by caching algorithms such as S3-FIFO, ARC, LIRS, CLOCK-Pro, etc.
-//
-// Semantics:
-//  - Tracks recently-evicted keys
-//  - Fixed capacity; evicts oldest entry (FIFO)
-//  - Membership test is O(1)
-//  - No TTL, no ranking, no frequency tracking
-//  - User must synchronize external concurrency
-//
-// Structure:
-//   deque<uint32_t>    : stores FIFO eviction order
-//   unordered_set<uint32_t> : stores O(1) membership
-//
 template <typename KeyT = uint32_t>
 class FIFOHashSetBase {
  public:
-  // @param capacity   Maximum number of ghost entries to keep.
   explicit FIFOHashSetBase(size_t capacity) : maxSize_{capacity} {
     if (capacity == 0) {
       throw std::invalid_argument{"GhostQueue capacity must be > 0"};
@@ -45,63 +26,94 @@ class FIFOHashSetBase {
   FIFOHashSetBase(const FIFOHashSetBase&) = delete;
   FIFOHashSetBase& operator=(const FIFOHashSetBase&) = delete;
 
-  FIFOHashSetBase(FIFOHashSetBase&& other) noexcept
-      : maxSize_{other.maxSize_},
-        fifo_{std::move(other.fifo_)},
-        set_{std::move(other.set_)} {
+  FIFOHashSetBase(FIFOHashSetBase&& other) noexcept {
+    maxSize_ = other.maxSize_;
+    fifo_ = std::move(other.fifo_);
+    set_ = std::move(other.set_);
     other.maxSize_ = 0;
   }
 
   FIFOHashSetBase& operator=(FIFOHashSetBase&& other) noexcept {
     if (this != &other) {
-      this->~FIFOHashSetBase();
-      new (this) FIFOHashSetBase(std::move(other));
+      maxSize_ = other.maxSize_;
+      fifo_ = std::move(other.fifo_);
+      set_ = std::move(other.set_);
+      other.maxSize_ = 0;
     }
     return *this;
   }
 
-  // O(1) membership check.
-  bool contains(KeyT key) const { return set_.find(key) != set_.end(); }
-
-  // Insert a key into ghost queue. If already present, no-op.
-  void insert(KeyT key) {
-    if (set_.count(key) > 0) {
-      return;
-    }
-
-    fifo_.push_back(key);
-    set_.insert(key);
-
-    enforceCapacity();
+  bool contains(KeyT key) {
+    return set_.contains(key);
   }
 
-  // Resize queue capacity (evicts oldest entries if shrinking).
+  // Enforce size variant of contains
+  bool containsEnforce(KeyT key) {
+    enforceCapacityLocked();
+    return set_.contains(key);
+  }
+
+  size_t size() {
+    return set_.size();
+  }
+
+  size_t capacity() {
+    return maxSize_;
+  }
+
+  void reserve(size_t newCap) {
+    set_.reserve(newCap);
+  }
+
+  void insert(KeyT key) {
+    auto [it, inserted] = set_.insert(key);
+    if (inserted) {
+      fifo_.push_back(key); 
+    }
+    enforceCapacityLocked();
+  }
+
+  // No enforce variant of insert
+  void insertNoEnforce(KeyT key) {
+    auto [it, inserted] = set_.insert(key);
+    if (inserted) {
+      fifo_.push_back(key);
+    }
+  }
+
   void resize(size_t newSize) {
     maxSize_ = newSize;
-    enforceCapacity();
+    enforceCapacityLocked();
   }
 
-  size_t size() const { return set_.size(); }
-
-  size_t capacity() const { return maxSize_; }
+  // No enforce variant of resize
+  void resizeNoEnforce(size_t newSize) {
+    maxSize_ = newSize;
+  }
 
  private:
-  // Remove oldest items until size <= capacity.
-  void enforceCapacity() {
-    while (fifo_.size() > maxSize_) {
+  // To prevent tail latency, limits max elements removed per call.
+  void enforceCapacityLocked() {
+    constexpr int max_rem = 5;
+    int removed = 0;
+
+    while (fifo_.size() > maxSize_ && removed < max_rem) {
       KeyT k = fifo_.front();
       fifo_.pop_front();
       set_.erase(k);
+      removed++;
     }
   }
 
  private:
+  // mutable folly::SpinLock lock_;
   size_t maxSize_{0};
-  std::deque<KeyT> fifo_{};
-  std::unordered_set<KeyT> set_{};
+  std::deque<KeyT> fifo_;
+  folly::F14FastSet<KeyT> set_;
 };
 
 } // namespace detail
-using FIFOHashSet = detail::FIFOHashSetBase<uint32_t>;
+
+using FIFOHashSet = detail::FIFOHashSetBase<uint64_t>;
 
 } // namespace facebook::cachelib::util

--- a/cachelib/common/FIFOHashSet.h
+++ b/cachelib/common/FIFOHashSet.h
@@ -77,9 +77,6 @@ class FIFOHashSetBase {
 
   // Resize queue capacity (evicts oldest entries if shrinking).
   void resize(size_t newSize) {
-    if (newSize == 0) {
-      throw std::invalid_argument{"GhostQueue capacity must be > 0"};
-    }
     maxSize_ = newSize;
     enforceCapacity();
   }

--- a/cachelib/common/FIFOHashSet.h
+++ b/cachelib/common/FIFOHashSet.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * ...
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <deque>
+#include <stdexcept>
+#include <unordered_set>
+
+namespace facebook::cachelib::util {
+
+namespace detail {
+
+// A bounded FIFO ghost list with O(1) membership check using a hash set.
+// Used by caching algorithms such as S3-FIFO, ARC, LIRS, CLOCK-Pro, etc.
+//
+// Semantics:
+//  - Tracks recently-evicted keys
+//  - Fixed capacity; evicts oldest entry (FIFO)
+//  - Membership test is O(1)
+//  - No TTL, no ranking, no frequency tracking
+//  - User must synchronize external concurrency
+//
+// Structure:
+//   deque<uint32_t>    : stores FIFO eviction order
+//   unordered_set<uint32_t> : stores O(1) membership
+//
+template <typename KeyT = uint32_t>
+class FIFOHashSetBase {
+ public:
+  // @param capacity   Maximum number of ghost entries to keep.
+  explicit FIFOHashSetBase(size_t capacity) : maxSize_{capacity} {
+    if (capacity == 0) {
+      throw std::invalid_argument{"GhostQueue capacity must be > 0"};
+    }
+  }
+
+  FIFOHashSetBase() = default;
+
+  FIFOHashSetBase(const FIFOHashSetBase&) = delete;
+  FIFOHashSetBase& operator=(const FIFOHashSetBase&) = delete;
+
+  FIFOHashSetBase(FIFOHashSetBase&& other) noexcept
+      : maxSize_{other.maxSize_},
+        fifo_{std::move(other.fifo_)},
+        set_{std::move(other.set_)} {
+    other.maxSize_ = 0;
+  }
+
+  FIFOHashSetBase& operator=(FIFOHashSetBase&& other) noexcept {
+    if (this != &other) {
+      this->~FIFOHashSetBase();
+      new (this) FIFOHashSetBase(std::move(other));
+    }
+    return *this;
+  }
+
+  // O(1) membership check.
+  bool contains(KeyT key) const { return set_.find(key) != set_.end(); }
+
+  // Insert a key into ghost queue. If already present, no-op.
+  void insert(KeyT key) {
+    if (set_.count(key) > 0) {
+      return;
+    }
+
+    fifo_.push_back(key);
+    set_.insert(key);
+
+    enforceCapacity();
+  }
+
+  // Resize queue capacity (evicts oldest entries if shrinking).
+  void resize(size_t newSize) {
+    if (newSize == 0) {
+      throw std::invalid_argument{"GhostQueue capacity must be > 0"};
+    }
+    maxSize_ = newSize;
+    enforceCapacity();
+  }
+
+  size_t size() const { return set_.size(); }
+
+  size_t capacity() const { return maxSize_; }
+
+ private:
+  // Remove oldest items until size <= capacity.
+  void enforceCapacity() {
+    while (fifo_.size() > maxSize_) {
+      KeyT k = fifo_.front();
+      fifo_.pop_front();
+      set_.erase(k);
+    }
+  }
+
+ private:
+  size_t maxSize_{0};
+  std::deque<KeyT> fifo_{};
+  std::unordered_set<KeyT> set_{};
+};
+
+} // namespace detail
+using FIFOHashSet = detail::FIFOHashSetBase<uint32_t>;
+
+} // namespace facebook::cachelib::util


### PR DESCRIPTION
This PR adds the S3FIFO eviction algorithm, as described [here](https://dl.acm.org/doi/pdf/10.1145/3600006.3613147).

Running cachebench results show that S3FIFO achieves the highest hit rate among all evaluated algorithms. Throughput wise, it performs similarly with TinyLFU.

Our implementation adapts the existing TinyLFUMM.

**Algorithm Detail**
The algorithm maintains three structures:
- S — a small queue for newly inserted items (10% of size)
- M — a main FIFO queue (90% of size)
- G — a ghost queue for items evicted from S (size of M), only tracks the object key hash.

The general idea of the algorithm is:
- Evict early: items in S are aggressively filtered to not pollute the main cache.
- Promote late: promotion/reinsertion occurs only when an accessed item reaches the tail.

Each object carries one access bit that records whether it has been accessed since it was inserted or last inspected.

Items in the tail are:
- If accessed and in S, moved to M.
- If accessed and in M, reinserted to head of M.
- If not accessed, evict. If this item is evicted from S, move it to the ghost queue.

Insertions are done as such:
- If the item exists in ghost, directly insert to M.
- Else insert to S.

We try to do eviction from S if the size > expected size (10%). Else, we try to evict from main.

Eviction iterator starts from tail and skips accessed items. Promotions (reinsertions) are done 1x before iterator is created.

**Benchmark:**
We evaluated S3FIFO using the test configurations in test_configs/hit_ratio with 48 threads and an 8 GB cache. We compared this against other existing MMContainers(LRU2Q, LRU, and TinyLFU).  We use the DebugRel release version for testing.

The results can be found here 
[S3 FIFO Benchmark (2).pdf](https://github.com/user-attachments/files/23684011/S3.FIFO.Benchmark.2.pdf)


**Miss ratio:**
S3FIFO consistently outperforms LRU, LRU2Q, and TinyLFU across all workloads.

**Throughput:**
Throughput is comparable to TinyLFU.

This implementation is not a throughput optimized version and still heavily uses LRU locks (in this case, TinyLFU's spinlocks). There maybe room for further improvement.


**Notes:**
- A FIFOHashSet is implemented to act as a ghost queue, using deque for maintaining FIFO order and unordered set for membership. 
- Several unused LRU configurations were removed as part of cleanup.


The parameters and the defaults are:
(1) Small / probationary queue size (default 10%)
Controls how long new objects stay in cache. If the workload has many low-reuse items (objects that appear only once or only a few times), making this smaller helps avoid pollution because these items get evicted quickly without entering the main cache.
(2) Large queue size (default 90%)
The rest of the cache. This is the “main” queue that holds objects with higher reuse.
(3) Ghost queue size (default 90%)
Stores only the key hashes of items evicted from the small queue. A larger ghost helps catch objects that return shortly after eviction. If the workload has many items that appear only twice and never come back again, the ghost queue can be made smaller since promoting these into the main queue doesn’t help.


For tuning, the paper shows that the small queue generally works best between 5% and 20% so those values can be tried out. If we have the proportion of the object reuse in the trace it can help us determine the sizes too.

<img width="1114" height="249" alt="image" src="https://github.com/user-attachments/assets/bef12848-775b-4d25-82d4-68f3886a36db" />


