### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -13,7 +13,7 @@ jobs:
           - 'cachelib'
           - 'examples'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Run clang-format style check for C/C++ programs.
       uses: jidicula/clang-format-action@v4.6.2
       with:

--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: 16-core-ubuntu
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Show disk space at start
       run: df -h
     - name: Free up disk space
@@ -662,7 +662,7 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. cachelib --project-install-prefix cachelib:/usr/local
     - name: Copy artifacts
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --strip --src-dir=. cachelib _artifacts/linux --project-install-prefix cachelib:/usr/local --final-install-prefix /usr/local
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: cachelib
         path: _artifacts


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [``](https://github.com/actions/checkout/releases/tag/) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) |  |
| `actions/upload-artifact` | [``](https://github.com/actions/upload-artifact/releases/tag/) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) |  |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
