### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run clang-format
-        uses: jidicula/clang-format-action@v4.13.0
+        uses: jidicula/clang-format-action@v4.18.0
         with:
           clang-format-version: '21'
           check-path: ${{ matrix.path }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -40,10 +40,10 @@ jobs:
         run: yarn build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: website/build
 
@@ -56,5 +56,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `actions/configure-pages` | [`v4`](https://github.com/actions/configure-pages/releases/tag/v4) | [`v6`](https://github.com/actions/configure-pages/releases/tag/v6) | [Diff](https://github.com/actions/configure-pages/compare/v4...v6) | deploy-website.yml |
| `actions/deploy-pages` | [`v4`](https://github.com/actions/deploy-pages/releases/tag/v4) | [`v5`](https://github.com/actions/deploy-pages/releases/tag/v5) | [Diff](https://github.com/actions/deploy-pages/compare/v4...v5) | deploy-website.yml |
| `actions/upload-pages-artifact` | [`v3`](https://github.com/actions/upload-pages-artifact/releases/tag/v3) | [`v5`](https://github.com/actions/upload-pages-artifact/releases/tag/v5) | [Diff](https://github.com/actions/upload-pages-artifact/compare/v3...v5) | deploy-website.yml |
| `jidicula/clang-format-action` | [`v4.13.0`](https://github.com/jidicula/clang-format-action/releases/tag/v4.13.0) | [`v4.18.0`](https://github.com/jidicula/clang-format-action/releases/tag/v4.18.0) | [Diff](https://github.com/jidicula/clang-format-action/compare/v4.13.0...v4.18.0) | clang-format-check.yml |

## Notes

Worth running the workflows on a branch before merging to make sure everything still works.
