### PR TITLE
[ci] Update GitHub Action mozilla-actions/sccache-action

### DIFF
--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Set up sccache
-      uses: mozilla-actions/sccache-action@v0.0.9
+      uses: mozilla-actions/sccache-action@v0.0.10
       with:
         version: "v0.14.0"
 


### PR DESCRIPTION
Fixes deprecation warning for node20.js